### PR TITLE
Correct the dbt constraint and bump package version

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -18,8 +18,8 @@ config-version: 2
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
 name: 'dbt_semantic_view'
-version: '0.1.1'
-require-dbt-version: ">=1.0.0,<2.0.0"
+version: '1.0.1'
+require-dbt-version: [">=1.0.0", "<2.0.0"]
 
 # This setting configures which "profile" dbt uses for this project.
 profile: 'dbt_semantic_view'


### PR DESCRIPTION
Fix: correct dbt version constraint format and bump package version to 1.0.1

The old version constraint `">=1.0.0,<2.0.0"` is corrected with `[">=1.0.0", "<2.0.0"]`, so that `dbt deps` could run successfully.
And plan to bump up the version with '1.0.1' so update accordingly.