### PR TITLE
Refactor: Refactor copy grants and disable persist_doc temporarily

### DIFF
--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -40,6 +40,9 @@ seeds:
 
 models:
   +bind: false
+  +persist_docs:
+    relation: true
+    column: true
 
 on-run-start:
   - "{{ create_base_table2() }}"

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -16,6 +16,8 @@
 version: 2
 
 models:
+  - name: semantic_view_basic
+    description: "Semantic view description for persist_docs"
   - name: semantic_view_with_config_copy_grants
     config:
       copy_grants: true

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -16,11 +16,12 @@
 version: 2
 
 models:
-  - name: semantic_view_basic
-    description: "Semantic view description for persist_docs"
   - name: semantic_view_with_config_copy_grants
     config:
       copy_grants: true
   - name: semantic_view_with_ddl_copy_grants_and_config_copy_grants
+    config:
+      copy_grants: true
+  - name: semantic_view_with_calc_name_copy_grants
     config:
       copy_grants: true

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -21,4 +21,6 @@ models:
   - name: semantic_view_with_config_copy_grants
     config:
       copy_grants: true
-  - name: semantic_view_with_copy_grants
+  - name: semantic_view_with_ddl_copy_grants_and_config_copy_grants
+    config:
+      copy_grants: true

--- a/integration_tests/models/semantic_view_with_calc_name_copy_grants.sql
+++ b/integration_tests/models/semantic_view_with_calc_name_copy_grants.sql
@@ -13,18 +13,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-{% materialization semantic_view, adapter='snowflake' -%}
-
-    {% set original_query_tag = set_query_tag() %}
-    {% do dbt_semantic_view.snowflake__create_or_replace_semantic_view() %}
-
-    {% set target_relation = this.incorporate(type='view') %}
-
-    -- TODO: enable this when semantic_view is part of the SnowflakeRelationType
-    -- {% do persist_docs(target_relation, model, for_columns=false) %}
-
-    {% do unset_query_tag(original_query_tag) %}
-
-    {% do return({'relations': [target_relation]}) %}
-
-{%- endmaterialization %}
+{{ config(materialized='semantic_view') }}
+TABLES(t1 AS {{ ref('base_table') }})
+DIMENSIONS(t1."COPY GRANTS" as value)
+METRICS(t1.total_rows AS SUM(t1."COPY GRANTS"))

--- a/integration_tests/models/semantic_view_with_ddl_copy_grants_and_config_copy_grants.sql
+++ b/integration_tests/models/semantic_view_with_ddl_copy_grants_and_config_copy_grants.sql
@@ -1,0 +1,20 @@
+-- Copyright 2025 Snowflake Inc. 
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+{{ config(materialized='semantic_view', copy_grants=true) }}
+TABLES(t1 AS {{ ref('base_table') }})
+DIMENSIONS(t1.count as value)
+METRICS(t1.total_rows AS SUM(t1.value))
+COPY   GRANTS

--- a/macros/materializations/semantic_view.sql
+++ b/macros/materializations/semantic_view.sql
@@ -20,7 +20,8 @@
 
     {% set target_relation = this.incorporate(type='view') %}
 
-    -- TODO: enable this when semantic_view is part of the SnowflakeRelationType
+    {# TODO: enable persist_docs after semantic_view is supported as a SnowflakeRelationType #}
+    {# {% do persist_docs(target_relation, model, for_columns=false) %} #}
 
     {% do unset_query_tag(original_query_tag) %}
 

--- a/macros/materializations/semantic_view.sql
+++ b/macros/materializations/semantic_view.sql
@@ -21,7 +21,6 @@
     {% set target_relation = this.incorporate(type='view') %}
 
     -- TODO: enable this when semantic_view is part of the SnowflakeRelationType
-    -- {% do persist_docs(target_relation, model, for_columns=false) %}
 
     {% do unset_query_tag(original_query_tag) %}
 

--- a/macros/relations/semantic_view/create.sql
+++ b/macros/relations/semantic_view/create.sql
@@ -58,14 +58,11 @@
 {% macro snowflake__create_or_replace_semantic_view() %}
   {%- set identifier = model['alias'] -%}
 
-  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
-  {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}
   {%- set copy_grants = config.get('copy_grants', default=false) -%}
 
   {%- set target_relation = api.Relation.create(
       identifier=identifier, schema=schema, database=database,
       type='view') -%}
-  {% set grant_config = config.get('grants') %}
 
   {%- if copy_grants -%}
     {%- set sql = dbt_semantic_view.append_copy_grants_if_missing(sql) -%}


### PR DESCRIPTION
1. Refactor copy grants handling by creating a utility function, it should be case-insensitive and space-incensitive.
2. Disable `persist_docs` and wait till the adapter support "semantic_view" as a valid SnowflakeRelationType.

```
(.venv) ➜  integration_tests git:(yutliu-refactor-copy-grants) ✗ dbt build --target snowflake
20:43:23  Running with dbt=1.10.11
20:43:24  Registered adapter: snowflake=1.10.2
20:43:24  Unable to do partial parsing because saved manifest not found. Starting full parse.
20:43:25  Found 9 models, 8 data tests, 1 seed, 2 operations, 2 sources, 487 macros
20:43:25  
20:43:25  Concurrency: 4 threads (target='snowflake')
20:43:25  
20:43:35  1 of 2 START hook: dbt_semantic_view_integration_tests.on-run-start.0 .......... [RUN]
20:43:35  1 of 2 OK hook: dbt_semantic_view_integration_tests.on-run-start.0 ............. [OK in 1.65s]
20:43:35  2 of 2 START hook: dbt_semantic_view_integration_tests.on-run-start.1 .......... [RUN]
20:43:35  2 of 2 OK hook: dbt_semantic_view_integration_tests.on-run-start.1 ............. [OK in 0.26s]
20:43:35  
20:43:35  1 of 18 START sql table model yutliu.table_refer_to_raw_semantic_view .......... [RUN]
20:43:35  2 of 18 START seed file yutliu_raw_data.my_seed ................................ [RUN]
20:43:37  1 of 18 OK created sql table model yutliu.table_refer_to_raw_semantic_view ..... [SUCCESS 1 in 1.38s]
20:43:37  3 of 18 START test table_refer_raw_semantic_view_matches_semantic_view ......... [RUN]
20:43:38  2 of 18 OK loaded seed file yutliu_raw_data.my_seed ............................ [INSERT 3 in 2.53s]
20:43:38  4 of 18 START test base_table .................................................. [RUN]
20:43:38  4 of 18 PASS base_table ........................................................ [PASS in 0.36s]
20:43:38  5 of 18 START sql table model yutliu.base_table ................................ [RUN]
20:43:39  5 of 18 OK created sql table model yutliu.base_table ........................... [SUCCESS 1 in 1.04s]
20:43:39  6 of 18 START sql semantic_view model yutliu.semantic_view_basic ............... [RUN]
20:43:39  7 of 18 START sql semantic_view model yutliu.semantic_view_with_ca_extension ... [RUN]
20:43:39  8 of 18 START sql semantic_view model yutliu.semantic_view_with_calc_name_copy_grants  [RUN]
20:43:40  6 of 18 OK created sql semantic_view model yutliu.semantic_view_basic .......... [SUCCESS 1 in 0.35s]
20:43:40  9 of 18 START sql semantic_view model yutliu.semantic_view_with_config_copy_grants  [RUN]
20:43:40  8 of 18 OK created sql semantic_view model yutliu.semantic_view_with_calc_name_copy_grants  [SUCCESS 1 in 0.37s]
20:43:40  10 of 18 START sql semantic_view model yutliu.semantic_view_with_copy_grants ... [RUN]
20:43:40  10 of 18 OK created sql semantic_view model yutliu.semantic_view_with_copy_grants  [SUCCESS 1 in 0.23s]
20:43:40  11 of 18 START sql semantic_view model yutliu.semantic_view_with_ddl_copy_grants_and_config_copy_grants  [RUN]
20:43:40  9 of 18 OK created sql semantic_view model yutliu.semantic_view_with_config_copy_grants  [SUCCESS 1 in 0.29s]
20:43:40  12 of 18 START test semantic_view_basic_has_comment ............................ [RUN]
20:43:40  11 of 18 OK created sql semantic_view model yutliu.semantic_view_with_ddl_copy_grants_and_config_copy_grants  [SUCCESS 1 in 0.26s]
20:43:40  13 of 18 START test semantic_view_basic_has_no_copy_grants ..................... [RUN]
20:43:40  12 of 18 PASS semantic_view_basic_has_comment .................................. [PASS in 0.43s]
20:43:40  14 of 18 START test semantic_view_sum_matches_base_table ....................... [RUN]
20:43:40  7 of 18 OK created sql semantic_view model yutliu.semantic_view_with_ca_extension  [SUCCESS 1 in 1.10s]
20:43:40  15 of 18 START test semantic_view_with_copy_has_copy_grants .................... [RUN]
20:43:41  13 of 18 PASS semantic_view_basic_has_no_copy_grants ........................... [PASS in 0.46s]
20:43:41  16 of 18 START test semantic_view_with_ca_extension_has_extension .............. [RUN]
20:43:41  15 of 18 PASS semantic_view_with_copy_has_copy_grants .......................... [PASS in 0.23s]
20:43:41  16 of 18 PASS semantic_view_with_ca_extension_has_extension .................... [PASS in 0.46s]
20:43:51  3 of 18 PASS table_refer_raw_semantic_view_matches_semantic_view ............... [PASS in 14.65s]
20:43:52  14 of 18 PASS semantic_view_sum_matches_base_table ............................. [PASS in 11.26s]
20:43:52  17 of 18 START sql table model yutliu.table_refer_to_semantic_view ............. [RUN]
20:43:53  17 of 18 OK created sql table model yutliu.table_refer_to_semantic_view ........ [SUCCESS 1 in 1.36s]
20:43:53  18 of 18 START test table_refer_semantic_view_matches_semantic_view ............ [RUN]
20:44:03  18 of 18 PASS table_refer_semantic_view_matches_semantic_view .................. [PASS in 9.55s]
20:44:03  
20:44:03  Finished running 2 project hooks, 1 seed, 6 semantic view models, 3 table models, 8 data tests in 0 hours 0 minutes and 38.83 seconds (38.83s).
20:44:03  
20:44:03  Completed successfully
20:44:03  
20:44:03  Done. PASS=20 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=20
(.venv) ➜  integration_tests git:(yutliu-refactor-copy-grants) ✗
```