### PR TITLE
Fix: Add customized persist_docs handling for semantic view

### DIFF
--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -30,6 +30,10 @@ clean-targets:
   - "target"
   - "dbt_packages"
 
+dispatch:
+  - macro_namespace: dbt
+    search_order: [dbt_semantic_view, dbt]
+
 flags:
   send_anonymous_usage_stats: False
   use_colors: True
@@ -40,6 +44,8 @@ seeds:
 
 models:
   +bind: false
+  +persist_docs:
+    relation: true
 
 on-run-start:
   - "{{ create_base_table2() }}"

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -16,8 +16,10 @@
 version: 2
 
 models:
-  - name: semantic_view_basic
+  - name: semantic_view_with_description
     description: "Semantic view description for persist_docs"
+  - name: semantic_view_with_comment_override_description
+    description: "Semantic view description overriding the model comment"
   - name: semantic_view_with_config_copy_grants
     config:
       copy_grants: true

--- a/integration_tests/models/semantic_view_with_comment_override_description.sql
+++ b/integration_tests/models/semantic_view_with_comment_override_description.sql
@@ -1,0 +1,21 @@
+-- Copyright 2025 Snowflake Inc. 
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+{{ config(materialized='semantic_view') }}
+
+TABLES(t1 AS {{ ref('base_table') }}, t2 as {{ source('seed_sources', 'base_table2') }})
+DIMENSIONS(t1.count as value, t2.volume as value)
+METRICS(t1.total_rows AS SUM(t1.count), t2.max_volume as max(t2.volume))
+COMMENT='COMMENT to be overridden by model description'

--- a/integration_tests/models/semantic_view_with_description.sql
+++ b/integration_tests/models/semantic_view_with_description.sql
@@ -1,0 +1,20 @@
+-- Copyright 2025 Snowflake Inc. 
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+{{ config(materialized='semantic_view') }}
+
+TABLES(t1 AS {{ ref('base_table') }}, t2 as {{ source('seed_sources', 'base_table2') }})
+DIMENSIONS(t1.count as value, t2.volume as value)
+METRICS(t1.total_rows AS SUM(t1.count), t2.max_volume as max(t2.volume))

--- a/integration_tests/tests/semantic_view_with_comment_override_description.sql
+++ b/integration_tests/tests/semantic_view_with_comment_override_description.sql
@@ -1,0 +1,20 @@
+-- Copyright 2025 Snowflake Inc. 
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+{{ config(materialized='test') }}
+
+-- Assert the semantic view's DDL contains the model description persisted via persist_docs
+select 'semantic view description missing' as error_message
+where position('semantic view description overriding the model comment' in lower(get_ddl('SEMANTIC_VIEW', '{{ ref('semantic_view_with_comment_override_description') }}'))) = 0

--- a/integration_tests/tests/semantic_view_with_description_has_comment.sql
+++ b/integration_tests/tests/semantic_view_with_description_has_comment.sql
@@ -1,0 +1,20 @@
+-- Copyright 2025 Snowflake Inc. 
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+{{ config(materialized='test') }}
+
+-- Assert the semantic view's DDL contains the model description persisted via persist_docs
+select 'semantic view description missing' as error_message
+where position('semantic view description for persist_docs' in lower(get_ddl('SEMANTIC_VIEW', '{{ ref('semantic_view_with_description_has_comment') }}'))) = 0

--- a/macros/adapters/persist_docs_semantic_view.sql
+++ b/macros/adapters/persist_docs_semantic_view.sql
@@ -1,0 +1,40 @@
+-- Copyright 2025 Snowflake Inc. 
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+{#
+  Override Snowflake relation comment behavior to support SEMANTIC VIEW.
+  dbt's SnowflakeRelationType does not include this custom type, so
+  we detect the materialization via model.config and emit the correct DDL.
+#}
+
+{% macro snowflake__alter_relation_comment(relation, relation_comment) -%}
+    {%- set is_semantic_view = (model is defined) and (model.config is defined) and (model.config.materialized == 'semantic_view') -%}
+
+    {%- if relation.is_dynamic_table -%}
+        {%- set relation_type = 'dynamic table' -%}
+    {%- elif is_semantic_view -%}
+        {%- set relation_type = 'semantic view' -%}
+    {%- else -%}
+        {%- set relation_type = relation.type | replace('_', ' ') -%}
+    {%- endif -%}
+
+    {%- if relation.is_iceberg_format and not is_semantic_view -%}
+        alter iceberg table {{ relation.render() }} set comment = $${{ relation_comment | replace('$', '[$]') }}$$;
+    {%- else -%}
+        comment on {{ relation_type }} {{ relation.render() }} IS $${{ relation_comment | replace('$', '[$]') }}$$;
+    {%- endif -%}
+{% endmacro %}
+
+


### PR DESCRIPTION
Add override of persist_docs handling for semantic view so it works.

```
(.venv) ➜  integration_tests git:(yutliu-fix-persist-docs) ✗ dbt build --target snowflake
22:26:15  Running with dbt=1.10.11
22:26:16  Registered adapter: snowflake=1.10.2
22:26:16  Unable to do partial parsing because saved manifest not found. Starting full parse.
22:26:16  [WARNING]: Test 'test.dbt_semantic_view_integration_tests.semantic_view_with_description_has_comment' (tests/semantic_view_with_description_has_comment.sql) depends on a node named 'semantic_view_with_description_has_comment' in package '' which was not found
22:26:17  Found 9 models, 9 data tests, 1 seed, 2 operations, 2 sources, 487 macros
22:26:17  
22:26:17  Concurrency: 4 threads (target='snowflake')
22:26:17  
22:26:30  1 of 2 START hook: dbt_semantic_view_integration_tests.on-run-start.0 .......... [RUN]
22:26:30  1 of 2 OK hook: dbt_semantic_view_integration_tests.on-run-start.0 ............. [OK in 2.26s]
22:26:31  2 of 2 START hook: dbt_semantic_view_integration_tests.on-run-start.1 .......... [RUN]
22:26:31  2 of 2 OK hook: dbt_semantic_view_integration_tests.on-run-start.1 ............. [OK in 0.27s]
22:26:31  
22:26:31  1 of 19 START sql table model yutliu.table_refer_to_raw_semantic_view .......... [RUN]
22:26:31  2 of 19 START seed file yutliu_raw_data.my_seed ................................ [RUN]
22:26:32  1 of 19 OK created sql table model yutliu.table_refer_to_raw_semantic_view ..... [SUCCESS 1 in 1.66s]
22:26:32  3 of 19 START test table_refer_raw_semantic_view_matches_semantic_view ......... [RUN]
22:26:34  3 of 19 PASS table_refer_raw_semantic_view_matches_semantic_view ............... [PASS in 1.91s]
22:26:34  2 of 19 OK loaded seed file yutliu_raw_data.my_seed ............................ [INSERT 3 in 3.73s]
22:26:34  4 of 19 START test base_table .................................................. [RUN]
22:26:35  4 of 19 PASS base_table ........................................................ [PASS in 0.27s]
22:26:35  5 of 19 START sql table model yutliu.base_table ................................ [RUN]
22:26:36  5 of 19 OK created sql table model yutliu.base_table ........................... [SUCCESS 1 in 1.62s]
22:26:36  6 of 19 START sql semantic_view model yutliu.semantic_view_basic ............... [RUN]
22:26:36  7 of 19 START sql semantic_view model yutliu.semantic_view_with_ca_extension ... [RUN]
22:26:36  8 of 19 START sql semantic_view model yutliu.semantic_view_with_comment_override_description  [RUN]
22:26:36  9 of 19 START sql semantic_view model yutliu.semantic_view_with_config_copy_grants  [RUN]
22:26:37  7 of 19 OK created sql semantic_view model yutliu.semantic_view_with_ca_extension  [SUCCESS 1 in 0.58s]
22:26:37  10 of 19 START sql semantic_view model yutliu.semantic_view_with_copy_grants ... [RUN]
22:26:37  9 of 19 OK created sql semantic_view model yutliu.semantic_view_with_config_copy_grants  [SUCCESS 1 in 0.65s]
22:26:37  11 of 19 START sql semantic_view model yutliu.semantic_view_with_description ... [RUN]
22:26:37  8 of 19 OK created sql semantic_view model yutliu.semantic_view_with_comment_override_description  [SUCCESS 1 in 0.74s]
22:26:37  12 of 19 START test semantic_view_with_ca_extension_has_extension .............. [RUN]
22:26:38  10 of 19 OK created sql semantic_view model yutliu.semantic_view_with_copy_grants  [SUCCESS 1 in 0.83s]
22:26:38  13 of 19 START test semantic_view_with_comment_override_description ............ [RUN]
22:26:38  6 of 19 OK created sql semantic_view model yutliu.semantic_view_basic .......... [SUCCESS 1 in 1.60s]
22:26:38  14 of 19 START test semantic_view_with_copy_has_copy_grants .................... [RUN]
22:26:38  11 of 19 OK created sql semantic_view model yutliu.semantic_view_with_description  [SUCCESS 1 in 0.97s]
22:26:38  15 of 19 START test semantic_view_basic_has_comment ............................ [RUN]
22:26:38  13 of 19 PASS semantic_view_with_comment_override_description .................. [PASS in 0.24s]
22:26:38  16 of 19 START test semantic_view_basic_has_no_copy_grants ..................... [RUN]
22:26:38  12 of 19 PASS semantic_view_with_ca_extension_has_extension .................... [PASS in 0.94s]
22:26:38  17 of 19 START test semantic_view_sum_matches_base_table ....................... [RUN]
22:26:38  16 of 19 PASS semantic_view_basic_has_no_copy_grants ........................... [PASS in 0.28s]
22:26:38  14 of 19 PASS semantic_view_with_copy_has_copy_grants .......................... [PASS in 0.35s]
22:26:38  15 of 19 PASS semantic_view_basic_has_comment .................................. [PASS in 0.39s]
22:26:39  17 of 19 PASS semantic_view_sum_matches_base_table ............................. [PASS in 0.60s]
22:26:39  18 of 19 START sql table model yutliu.table_refer_to_semantic_view ............. [RUN]
22:26:40  18 of 19 OK created sql table model yutliu.table_refer_to_semantic_view ........ [SUCCESS 1 in 1.57s]
22:26:40  19 of 19 START test table_refer_semantic_view_matches_semantic_view ............ [RUN]
22:26:41  19 of 19 PASS table_refer_semantic_view_matches_semantic_view .................. [PASS in 0.85s]
22:26:42  
22:26:42  Finished running 2 project hooks, 1 seed, 6 semantic view models, 3 table models, 9 data tests in 0 hours 0 minutes and 25.61 seconds (25.61s).
22:26:42  
22:26:42  Completed successfully
22:26:42  
22:26:42  Done. PASS=21 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=21
(.venv) ➜  integration_tests git:(yutliu-fix-persist-docs) ✗  
```