### PR TITLE
Add persist_docs support for semantic views

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,37 @@ from semantic_view(
 )
 ```
 
-### Note on documentation persistence (persist_docs)
-At this time, dbt-driven documentation persistence for Semantic Views (persist_docs) is not supported by this package. Enabling `persist_docs` and adding model or column descriptions will not affect Semantic Views.
+### Documentation persistence (persist_docs)
+This package supports dbt-driven documentation persistence for Semantic Views through the `persist_docs` configuration. When enabled, model descriptions from `schema.yml` will be automatically added as `COMMENT` clauses to the Semantic View DDL.
 
-Inline COMMENT syntax within the Semantic View DDL is supported and will be applied by Snowflake. For example:
+To enable persist_docs for relation-level comments:
+```yaml
+# In your model config
+{{ config(
+    materialized='semantic_view',
+    persist_docs={'relation': true}
+) }}
+```
+
+Or in `dbt_project.yml`:
+```yaml
+models:
+  your_project:
+    +persist_docs:
+      relation: true
+```
+
+When persist_docs is enabled, the model description from `schema.yml` will be applied:
+```yaml
+# schema.yml
+models:
+  - name: my_semantic_view
+    description: "This description will become a COMMENT"
+```
+
+**Note**: Column-level persist_docs is not supported as Semantic Views use DIMENSIONS, METRICS, and FACTS rather than traditional columns.
+
+Inline COMMENT syntax within the Semantic View DDL is also supported:
 ```
 CREATE OR REPLACE SEMANTIC VIEW <name>
   TABLES ( ... COMMENT = '...' )
@@ -90,8 +117,6 @@ CREATE OR REPLACE SEMANTIC VIEW <name>
   [ METRICS ( ... COMMENT = '...' ) ]
   [ COMMENT = '...' ]
 ```
-
-We plan to revisit persist_docs support as upstream capabilities evolve.
 
 ### Development
 - Python 3.9+ recommended

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ models:
     description: "This description becomes the semantic view COMMENT"
 ```
 
-If the model SQL body already ends with its own `COMMENT=` clause, that one wins and nothing is appended.
+If the model SQL body already contains a `COMMENT=` clause, nothing is appended — the DDL in the model wins.
 
 Column-level `persist_docs` is not supported — semantic views expose DIMENSIONS, METRICS, and FACTS rather than columns. Use inline `COMMENT` syntax in the DDL for those:
 

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -27,3 +27,5 @@ models:
   - name: semantic_view_with_calc_name_copy_grants
     config:
       copy_grants: true
+  - name: semantic_view_with_persist_docs
+    description: "This semantic view tests persist_docs functionality"

--- a/integration_tests/models/semantic_view_with_materializations.sql
+++ b/integration_tests/models/semantic_view_with_materializations.sql
@@ -59,5 +59,5 @@ materializations:
 TABLES(t1 AS {{ ref('base_table') }})
 DIMENSIONS(t1.count as value)
 METRICS(t1.total_rows AS SUM(t1.count))
-MAX_STALENESS = '1 hour'
 COMMENT='semantic view with materialization for integration test'
+MAX_STALENESS = '1 hour'

--- a/integration_tests/models/semantic_view_with_persist_docs.sql
+++ b/integration_tests/models/semantic_view_with_persist_docs.sql
@@ -13,17 +13,11 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-{% materialization semantic_view, adapter='snowflake' -%}
+{{ config(
+    materialized='semantic_view',
+    persist_docs={'relation': true}
+) }}
 
-    {% set original_query_tag = set_query_tag() %}
-    {% do dbt_semantic_view.snowflake__create_or_replace_semantic_view() %}
-
-    {% set target_relation = this.incorporate(type='view') %}
-
-    {# persist_docs is now handled within the create macro for semantic views #}
-
-    {% do unset_query_tag(original_query_tag) %}
-
-    {% do return({'relations': [target_relation]}) %}
-
-{%- endmaterialization %}
+TABLES(t1 AS {{ ref('base_table') }}, t2 as {{ source('seed_sources', 'base_table2') }})
+DIMENSIONS(t1.count as value, t2.volume as value)
+METRICS(t1.total_rows AS SUM(t1.count), t2.max_volume as max(t2.volume))

--- a/integration_tests/tests/semantic_view_basic_no_persist_docs.sql
+++ b/integration_tests/tests/semantic_view_basic_no_persist_docs.sql
@@ -13,17 +13,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-{% materialization semantic_view, adapter='snowflake' -%}
-
-    {% set original_query_tag = set_query_tag() %}
-    {% do dbt_semantic_view.snowflake__create_or_replace_semantic_view() %}
-
-    {% set target_relation = this.incorporate(type='view') %}
-
-    {# persist_docs is now handled within the create macro for semantic views #}
-
-    {% do unset_query_tag(original_query_tag) %}
-
-    {% do return({'relations': [target_relation]}) %}
-
-{%- endmaterialization %}
+-- Test that without persist_docs config, the schema.yml description is NOT added as a COMMENT
+-- (semantic_view_basic has a description but no persist_docs config)
+select 'description incorrectly added without persist_docs' as error_message
+where position('comment=''Semantic view description for persist_docs''' in lower(get_ddl('SEMANTIC_VIEW', '{{ ref('semantic_view_basic') }}'))) > 0

--- a/integration_tests/tests/semantic_view_with_persist_docs_has_comment.sql
+++ b/integration_tests/tests/semantic_view_with_persist_docs_has_comment.sql
@@ -13,17 +13,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-{% materialization semantic_view, adapter='snowflake' -%}
-
-    {% set original_query_tag = set_query_tag() %}
-    {% do dbt_semantic_view.snowflake__create_or_replace_semantic_view() %}
-
-    {% set target_relation = this.incorporate(type='view') %}
-
-    {# persist_docs is now handled within the create macro for semantic views #}
-
-    {% do unset_query_tag(original_query_tag) %}
-
-    {% do return({'relations': [target_relation]}) %}
-
-{%- endmaterialization %}
+-- Test that persist_docs adds the model description as a COMMENT
+select 'persist_docs comment missing' as error_message
+where position('comment=' in lower(get_ddl('SEMANTIC_VIEW', '{{ ref('semantic_view_with_persist_docs') }}'))) = 0
+   or position('this semantic view tests persist_docs functionality' in lower(get_ddl('SEMANTIC_VIEW', '{{ ref('semantic_view_with_persist_docs') }}'))) = 0

--- a/macros/relations/semantic_view/create.sql
+++ b/macros/relations/semantic_view/create.sql
@@ -123,22 +123,23 @@
     {%- endif -%}
   {%- endif -%}
 
-  {# Inject max_staleness from config into the SQL body #}
-  {%- if max_staleness is not none -%}
-    {%- if 'max_staleness' in (sql | lower) -%}
-      {{ exceptions.raise_compiler_error(
-          "max_staleness is defined in both config() and the model SQL body. Remove one."
-      ) }}
-    {%- endif -%}
-    {%- set sql = sql ~ "\nMAX_STALENESS = '" ~ max_staleness ~ "'" -%}
+  {%- if max_staleness is not none and 'max_staleness' in (sql | lower) -%}
+    {{ exceptions.raise_compiler_error(
+        "max_staleness is defined in both config() and the model SQL body. Remove one."
+    ) }}
   {%- endif -%}
 
   {%- set target_relation = api.Relation.create(
       identifier=identifier, schema=schema, database=database,
       type='view') -%}
 
+  {# Trailing clauses must follow Snowflake's DDL order: COMMENT, MAX_STALENESS, COPY GRANTS #}
   {%- if relation_comment -%}
     {%- set sql = dbt_semantic_view.append_comment_if_missing(sql, relation_comment) -%}
+  {%- endif -%}
+
+  {%- if max_staleness is not none -%}
+    {%- set sql = sql ~ "\nMAX_STALENESS = '" ~ max_staleness ~ "'" -%}
   {%- endif -%}
 
   {%- if copy_grants and not create_or_alter -%}

--- a/macros/relations/semantic_view/create.sql
+++ b/macros/relations/semantic_view/create.sql
@@ -67,7 +67,8 @@
     {%- if has_comment -%}
       {%- set out = s -%}
     {%- else -%}
-      {%- set out = s ~ "\nCOMMENT='" ~ comment ~ "'" -%}
+      {# escape single quotes so a description cannot terminate the string literal #}
+      {%- set out = s ~ "\nCOMMENT='" ~ (comment | replace("'", "''")) ~ "'" -%}
     {%- endif -%}
 
     {{- out -}}


### PR DESCRIPTION
## Summary
Implements relation-level `persist_docs` functionality for semantic views, addressing the "persist_docs not supported" limitation mentioned in the README and resolving the TODO comment in the materialization.

- ✅ Automatically adds model descriptions from `schema.yml` as `COMMENT` clauses to Semantic View DDL
- ✅ Detects and avoids conflicts with existing inline `COMMENT` syntax  
- ✅ Follows the existing `copy_grants` pattern for consistency
- ✅ Includes comprehensive test coverage for enabled and disabled scenarios

## Usage Example
```yaml
# schema.yml
models:
  - name: my_semantic_view
    description: "Customer metrics for analysis"

# model config
{{ config(
    materialized='semantic_view',
    persist_docs={'relation': true}
) }}
```

Results in DDL with: `COMMENT='Customer metrics for analysis'`

## Test Plan
- [x] Added test model with persist_docs enabled
- [x] Added positive test verifying comment is added when enabled
- [x] Added negative test verifying comment is NOT added when disabled  
- [x] Verified existing inline COMMENT syntax is preserved
- [x] Tested on actual Snowflake environment

## Changes
- Updated `macros/relations/semantic_view/create.sql` with new `append_comment_if_missing` macro
- Modified `macros/materializations/semantic_view.sql` to remove TODO comment
- Enhanced README with persist_docs documentation and usage examples
- Added integration test model and test cases