### PR TITLE
Fusion compatibility for integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dbt_modules/
 *venv*/
 .DS_Store
 .env
+dbt_internal_packages/

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -42,7 +42,7 @@ models:
   +bind: false
   +persist_docs:
     relation: true
-    column: true
+    columns: true
 
 on-run-start:
   - "{{ create_base_table2() }}"

--- a/integration_tests/models/semantic_view_basic.sql
+++ b/integration_tests/models/semantic_view_basic.sql
@@ -13,7 +13,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-{{ config(materialized='semantic_view') }}
+{{ config(materialized='semantic_view', static_analysis='off') }}
 
 TABLES(t1 AS {{ ref('base_table') }}, t2 as {{ source('seed_sources', 'base_table2') }})
 DIMENSIONS(t1.count as value, t2.volume as value)

--- a/integration_tests/models/semantic_view_with_ca_extension.sql
+++ b/integration_tests/models/semantic_view_with_ca_extension.sql
@@ -13,7 +13,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-{{ config(materialized='semantic_view') }}
+{{ config(materialized='semantic_view', static_analysis='off') }}
 TABLES(t1 AS {{ ref('base_table') }}, t2 as {{ source('seed_sources', 'base_table2') }})
 DIMENSIONS(t1.count as value, t2.volume as value)
 METRICS(t1.total_rows AS SUM(t1.count), t2.max_volume as max(t2.volume))

--- a/integration_tests/models/semantic_view_with_calc_name_copy_grants.sql
+++ b/integration_tests/models/semantic_view_with_calc_name_copy_grants.sql
@@ -13,7 +13,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-{{ config(materialized='semantic_view') }}
+{{ config(materialized='semantic_view', static_analysis='off') }}
 TABLES(t1 AS {{ ref('base_table') }})
 DIMENSIONS(t1."COPY GRANTS" as value)
 METRICS(t1.total_rows AS SUM(t1."COPY GRANTS"))

--- a/integration_tests/models/semantic_view_with_config_copy_grants.sql
+++ b/integration_tests/models/semantic_view_with_config_copy_grants.sql
@@ -13,7 +13,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-{{ config(materialized='semantic_view') }}
+{{ config(materialized='semantic_view', static_analysis='off') }}
 TABLES(t1 AS {{ ref('base_table') }})
 DIMENSIONS(t1.count as value)
 METRICS(t1.total_rows AS SUM(t1.value))

--- a/integration_tests/models/semantic_view_with_copy_grants.sql
+++ b/integration_tests/models/semantic_view_with_copy_grants.sql
@@ -13,7 +13,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-{{ config(materialized='semantic_view') }}
+{{ config(materialized='semantic_view', static_analysis='off') }}
 TABLES(t1 AS {{ ref('base_table') }})
 DIMENSIONS(t1.count as value)
 METRICS(t1.total_rows AS SUM(t1.value))

--- a/integration_tests/models/semantic_view_with_ddl_copy_grants_and_config_copy_grants.sql
+++ b/integration_tests/models/semantic_view_with_ddl_copy_grants_and_config_copy_grants.sql
@@ -13,7 +13,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-{{ config(materialized='semantic_view', copy_grants=true) }}
+{{ config(materialized='semantic_view', copy_grants=true, static_analysis='off') }}
 TABLES(t1 AS {{ ref('base_table') }})
 DIMENSIONS(t1.count as value)
 METRICS(t1.total_rows AS SUM(t1.value))


### PR DESCRIPTION
Make the integration tests run on Fusion. The package itself is already Fusion compatible.

- fix a typo for `persist_docs.column`
- turn static analysis off for `semantic_view` models