### PR TITLE
Verified queries implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,39 @@ TABLES(
 [ FACTS ( semanticExpression [ , ... ] ) ]
 [ DIMENSIONS ( semanticExpression [ , ... ] ) ]
 [ METRICS ( semanticExpression [ , ... ] ) ]
+[ WITH EXTENSION ( CA = '<json>' ) ]
 [ COMMENT = '<comment>' ]
 [ COPY GRANTS ]
 ```
+
+#### Verified queries (Cortex Analyst extension)
+Snowflake Semantic Views can store “verified queries” in the `CA` extension. This package supports a `verified_queries` model config that will append a `WITH EXTENSION (CA = '<json>')` clause at materialization time.
+
+Example:
+```
+{{ config(
+    materialized='semantic_view',
+    verified_queries=[
+      {
+        "name": "Orders by day",
+        "question": "How many orders per day?",
+        "sql": "select * from orders_by_day"
+      },
+      {
+        "name": "Revenue by month",
+        "question": "What is revenue by month?",
+        "sql": "select * from revenue_by_month"
+      }
+    ]
+) }}
+
+TABLES(...)
+DIMENSIONS(...)
+METRICS(...)
+```
+
+Notes:
+- If your model SQL already includes a `WITH EXTENSION (...)` clause, this package will **not** attempt to merge extensions.
 
 Reference a Semantic View from another model:
 ```

--- a/integration_tests/models/semantic_view_with_ca_extension.sql
+++ b/integration_tests/models/semantic_view_with_ca_extension.sql
@@ -13,8 +13,16 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-{{ config(materialized='semantic_view') }}
+{{ config(
+    materialized='semantic_view',
+    verified_queries=[
+      {
+        "name": "hi",
+        "question": "hello",
+        "sql": "select 1"
+      }
+    ]
+) }}
 TABLES(t1 AS {{ ref('base_table') }}, t2 as {{ source('seed_sources', 'base_table2') }})
 DIMENSIONS(t1.count as value, t2.volume as value)
 METRICS(t1.total_rows AS SUM(t1.count), t2.max_volume as max(t2.volume))
-with extension (CA = '{"verified_queries":[{"name":"hi", "question": "hello"}]')

--- a/integration_tests/tests/semantic_view_with_ca_extension_has_extension.sql
+++ b/integration_tests/tests/semantic_view_with_ca_extension_has_extension.sql
@@ -19,7 +19,7 @@
 select 'CA extension missing or values mismatch for SEMANTIC_VIEW_WITH_CA_EXTENSION' as error_message
 where not (
   position('ca' in lower(get_ddl('SEMANTIC_VIEW', '{{ ref('semantic_view_with_ca_extension') }}'))) > 0
-  and position('"verified_queries":[{"name":"hi", "question": "hello"}]' in lower(get_ddl('SEMANTIC_VIEW', '{{ ref('semantic_view_with_ca_extension') }}'))) > 0
+  and position('"verified_queries":[{"name":"hi","question":"hello"}]' in lower(get_ddl('SEMANTIC_VIEW', '{{ ref('semantic_view_with_ca_extension') }}'))) > 0
 )
 
 

--- a/macros/relations/semantic_view/create.sql
+++ b/macros/relations/semantic_view/create.sql
@@ -32,6 +32,26 @@
 {%- endmacro %}
 
 
+{% macro append_ca_extension_if_missing(sql, ca_json) -%}
+  {%- set s = (sql | trim) -%}
+  {%- if not s -%}
+    {{- s -}}
+  {%- else -%}
+    {%- set had_semicolon = (s[-1:] == ';') -%}
+    {%- if had_semicolon -%}
+      {%- set s = (s[:-1] | trim) -%}
+    {%- endif -%}
+
+    {# If the model SQL already includes a WITH EXTENSION clause, do not try to merge. #}
+    {%- if 'with extension' in (s | lower) -%}
+      {{- s -}}
+    {%- else -%}
+      {%- set out = s ~ "\nWITH EXTENSION (CA = '" ~ ca_json ~ "')" -%}
+      {{- out -}}
+    {%- endif -%}
+  {%- endif -%}
+{%- endmacro %}
+
 {% macro append_copy_grants_if_missing(sql) -%}
   {%- set s = (sql | trim) -%}
   {%- set had_semicolon = (s[-1:] == ';') -%}
@@ -59,6 +79,7 @@
   {%- set identifier = model['alias'] -%}
 
   {%- set copy_grants = config.get('copy_grants', default=false) -%}
+  {%- set verified_queries = config.get('verified_queries', default=none) -%}
 
   {%- set target_relation = api.Relation.create(
       identifier=identifier, schema=schema, database=database,
@@ -66,6 +87,11 @@
 
   {%- if copy_grants -%}
     {%- set sql = dbt_semantic_view.append_copy_grants_if_missing(sql) -%}
+  {%- endif -%}
+
+  {%- if verified_queries is not none -%}
+    {%- set ca_json = {'verified_queries': verified_queries} | tojson -%}
+    {%- set sql = dbt_semantic_view.append_ca_extension_if_missing(sql, ca_json) -%}
   {%- endif -%}
 
   {{ run_hooks(pre_hooks) }}


### PR DESCRIPTION
Currently, the setup for verified queries is tricky and undocumented. This PR introduces an easier way to configure verified queries via a config macro, without breaking the existing `with extension (CA = '{...}')` workaround.

Example:
```sql
{{ config(
    materialized='semantic_view',
    verified_queries=[
      {
        "name": "Orders by day",
        "question": "How many orders did we have each day last month?",
        "sql": "select order_date, count(*) as orders from __orders group by order_date"
      },
      {
        "name": "Revenue by month",
        "question": "What is total revenue by month?",
        "sql": "select month, sum(revenue) as total_revenue from __orders_by_month group by month"
      }
    ]
) }}

TABLES(orders as {{ ref('orders') }})
DIMENSIONS(orders.order_date, orders.month)
METRICS(orders.total_revenue as sum(orders.revenue))
```

NOTE:
Unfortunately, I do not have access to a personal Snowflake account to test this PR. I would appreciate it if someone could test it and confirm whether it passes the test cases.