### PR TITLE
fix: dbt build --empty compatibility via sv_ref/sv_source macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,33 @@ from semantic_view(
 )
 ```
 
+### Referencing tables with `sv_ref()` and `sv_source()`
+
+Snowflake Semantic View DDL requires bare `DATABASE.SCHEMA.IDENTIFIER` table references in `TABLES()` clauses and `semantic_view()` function calls. dbt's `--empty` flag rewrites `ref()` and `source()` into `(SELECT ... LIMIT 0)` subqueries, which breaks this syntax.
+
+`sv_ref()` and `sv_source()` render the fully-qualified identifier directly while still registering the dependency in the dbt DAG, so lineage and catalog integration work as expected.
+
+**When to use them:** only inside `TABLES()` clauses in semantic view model definitions, and inside `semantic_view()` function calls in downstream query models. Use standard `ref()` and `source()` everywhere else (normal `SELECT` statements, `WHERE` clauses, CTEs, etc.).
+
+Defining a semantic view:
+```sql
+{{ config(materialized='semantic_view') }}
+
+TABLES(t1 AS {{ dbt_semantic_view.sv_ref('base_table') }})
+DIMENSIONS(t1.count as value)
+METRICS(t1.total_rows AS SUM(t1.count))
+```
+
+Querying a semantic view from a downstream model:
+```sql
+select * from semantic_view({{ dbt_semantic_view.sv_ref('my_semantic_view') }} metrics total_rows)
+```
+
+Using a source table:
+```sql
+TABLES(t1 AS {{ dbt_semantic_view.sv_source('my_source', 'my_table') }})
+```
+
 ### Note on documentation persistence (persist_docs)
 At this time, dbt-driven documentation persistence for Semantic Views (persist_docs) is not supported by this package. Enabling `persist_docs` and adding model or column descriptions will not affect Semantic Views.
 

--- a/README.md
+++ b/README.md
@@ -105,20 +105,29 @@ Using a source table:
 TABLES(t1 AS {{ dbt_semantic_view.sv_source('my_source', 'my_table') }})
 ```
 
-### Note on documentation persistence (persist_docs)
-At this time, dbt-driven documentation persistence for Semantic Views (persist_docs) is not supported by this package. Enabling `persist_docs` and adding model or column descriptions will not affect Semantic Views.
+### Documentation persistence (persist_docs)
+This package supports both relation-level and column-level `persist_docs` for Semantic Views.
 
-Inline COMMENT syntax within the Semantic View DDL is supported and will be applied by Snowflake. For example:
-```
-CREATE OR REPLACE SEMANTIC VIEW <name>
-  TABLES ( ... COMMENT = '...' )
-  [ FACTS ( ... COMMENT = '...' ) ]
-  [ DIMENSIONS ( ... COMMENT = '...' ) ]
-  [ METRICS ( ... COMMENT = '...' ) ]
-  [ COMMENT = '...' ]
+**Relation-level** — enable `persist_docs: {relation: true}` and add a model `description:` in `schema.yml`. The description is emitted as a top-level `COMMENT = $$...$$` on the `CREATE OR REPLACE SEMANTIC VIEW` statement. If your model already writes an inline top-level `COMMENT = ...`, it is preserved unchanged (**inline SQL wins**).
+
+**Column-level (dimensions / metrics / facts)** — Snowflake requires dim/metric/fact `COMMENT` clauses to be emitted inline at create time (they cannot be added via `ALTER SEMANTIC VIEW`). Enable `persist_docs: {columns: true}`. Write your semantic view using the standard Snowflake syntax. At materialize time the package scans each `DIMENSIONS`/`METRICS`/`FACTS` entry and, when the RHS of `AS` is a simple column reference (optionally alias-qualified, e.g., `value` or `t1.value`) and the LHS is alias-qualified, looks up the underlying `schema.yml` / `source.yml` column description and appends `COMMENT = $$…$$` to that entry. Entries that already contain an inline `COMMENT = …` are left untouched (inline wins). Column lookups always resolve against the table behind the **LHS alias**, so cross-alias RHS references like `t1.my_dim AS t2.col` will pull the description for `col` from `t1`'s underlying table, not `t2`'s — if the two tables don't share that column, no comment is emitted.
+
+Example — mirrors `integration_tests/models/semantic_view_with_persist_docs.sql`:
+
+```sql
+{{ config(materialized='semantic_view') }}
+
+TABLES(t1 AS {{ dbt_semantic_view.sv_ref('base_table') }}, t2 AS {{ dbt_semantic_view.sv_source('seed_sources', 'base_table2') }})
+DIMENSIONS(
+  t1.count AS value,
+  t2.volume AS value
+)
+METRICS(
+  t1.total_rows AS SUM(t1.count) COMMENT = $$Total row count aggregate$$
+)
 ```
 
-We plan to revisit persist_docs support as upstream capabilities evolve.
+With a model `description:` in `schema.yml` and project-wide `persist_docs: {relation: true, columns: true}`, this renders a single `CREATE OR REPLACE SEMANTIC VIEW` with a top-level `COMMENT`, plus per-dim `COMMENT = $$Generic numeric value column$$` resolved from the underlying `base_table.value` / `base_table2.value` descriptions. The metric's inline `COMMENT = $$Total row count aggregate$$` is preserved as-is — inline always wins.
 
 ### Development
 - Python 3.9+ recommended

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -42,7 +42,7 @@ models:
   +bind: false
   +persist_docs:
     relation: true
-    column: true
+    columns: true
 
 on-run-start:
   - "{{ create_base_table2() }}"

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -27,3 +27,12 @@ models:
   - name: semantic_view_with_calc_name_copy_grants
     config:
       copy_grants: true
+  - name: base_table
+    description: "Base table used as a source for semantic views"
+    columns:
+      - name: id
+        description: "Row identifier"
+      - name: value
+        description: "Generic numeric value column"
+  - name: semantic_view_with_persist_docs
+    description: "Semantic view exercising both relation and column persist_docs"

--- a/integration_tests/models/semantic_view_basic.sql
+++ b/integration_tests/models/semantic_view_basic.sql
@@ -15,7 +15,7 @@
 
 {{ config(materialized='semantic_view') }}
 
-TABLES(t1 AS {{ ref('base_table') }}, t2 as {{ source('seed_sources', 'base_table2') }})
+TABLES(t1 AS {{ dbt_semantic_view.sv_ref('base_table') }}, t2 as {{ dbt_semantic_view.sv_source('seed_sources', 'base_table2') }})
 DIMENSIONS(t1.count as value, t2.volume as value)
 METRICS(t1.total_rows AS SUM(t1.count), t2.max_volume as max(t2.volume))
 COMMENT='test semantic view'

--- a/integration_tests/models/semantic_view_with_ca_extension.sql
+++ b/integration_tests/models/semantic_view_with_ca_extension.sql
@@ -14,7 +14,7 @@
 -- limitations under the License.
 
 {{ config(materialized='semantic_view') }}
-TABLES(t1 AS {{ ref('base_table') }}, t2 as {{ source('seed_sources', 'base_table2') }})
+TABLES(t1 AS {{ dbt_semantic_view.sv_ref('base_table') }}, t2 as {{ dbt_semantic_view.sv_source('seed_sources', 'base_table2') }})
 DIMENSIONS(t1.count as value, t2.volume as value)
 METRICS(t1.total_rows AS SUM(t1.count), t2.max_volume as max(t2.volume))
 with extension (CA = '{"verified_queries":[{"name":"hi", "question": "hello"}]')

--- a/integration_tests/models/semantic_view_with_calc_name_copy_grants.sql
+++ b/integration_tests/models/semantic_view_with_calc_name_copy_grants.sql
@@ -14,6 +14,6 @@
 -- limitations under the License.
 
 {{ config(materialized='semantic_view') }}
-TABLES(t1 AS {{ ref('base_table') }})
+TABLES(t1 AS {{ dbt_semantic_view.sv_ref('base_table') }})
 DIMENSIONS(t1."COPY GRANTS" as value)
 METRICS(t1.total_rows AS SUM(t1."COPY GRANTS"))

--- a/integration_tests/models/semantic_view_with_config_copy_grants.sql
+++ b/integration_tests/models/semantic_view_with_config_copy_grants.sql
@@ -14,6 +14,6 @@
 -- limitations under the License.
 
 {{ config(materialized='semantic_view') }}
-TABLES(t1 AS {{ ref('base_table') }})
+TABLES(t1 AS {{ dbt_semantic_view.sv_ref('base_table') }})
 DIMENSIONS(t1.count as value)
 METRICS(t1.total_rows AS SUM(t1.value))

--- a/integration_tests/models/semantic_view_with_copy_grants.sql
+++ b/integration_tests/models/semantic_view_with_copy_grants.sql
@@ -14,7 +14,7 @@
 -- limitations under the License.
 
 {{ config(materialized='semantic_view') }}
-TABLES(t1 AS {{ ref('base_table') }})
+TABLES(t1 AS {{ dbt_semantic_view.sv_ref('base_table') }})
 DIMENSIONS(t1.count as value)
 METRICS(t1.total_rows AS SUM(t1.value))
 COMMENT='test semantic view explicit copy grants'

--- a/integration_tests/models/semantic_view_with_ddl_copy_grants_and_config_copy_grants.sql
+++ b/integration_tests/models/semantic_view_with_ddl_copy_grants_and_config_copy_grants.sql
@@ -14,7 +14,7 @@
 -- limitations under the License.
 
 {{ config(materialized='semantic_view', copy_grants=true) }}
-TABLES(t1 AS {{ ref('base_table') }})
+TABLES(t1 AS {{ dbt_semantic_view.sv_ref('base_table') }})
 DIMENSIONS(t1.count as value)
 METRICS(t1.total_rows AS SUM(t1.value))
 COPY   GRANTS

--- a/integration_tests/models/semantic_view_with_dotted_rhs.sql
+++ b/integration_tests/models/semantic_view_with_dotted_rhs.sql
@@ -1,0 +1,8 @@
+{{ config(materialized='semantic_view') }}
+
+TABLES (
+  t1 AS {{ dbt_semantic_view.sv_ref('base_table') }}
+)
+DIMENSIONS(
+  t1.value AS t1.value
+)

--- a/integration_tests/models/semantic_view_with_mixed_trailing_clauses.sql
+++ b/integration_tests/models/semantic_view_with_mixed_trailing_clauses.sql
@@ -1,0 +1,10 @@
+{{ config(materialized='semantic_view') }}
+
+TABLES (
+  t1 AS {{ dbt_semantic_view.sv_ref('base_table') }} UNIQUE (id),
+  t2 AS {{ dbt_semantic_view.sv_source('seed_sources', 'base_table2') }} WITH SYNONYMS ('bt2', 'alias2')
+)
+DIMENSIONS(
+  t1.value_from_schema AS value,
+  t2.value_from_source AS value
+)

--- a/integration_tests/models/semantic_view_with_persist_docs.sql
+++ b/integration_tests/models/semantic_view_with_persist_docs.sql
@@ -1,0 +1,10 @@
+{{ config(materialized='semantic_view') }}
+
+TABLES(t1 AS {{ dbt_semantic_view.sv_ref('base_table') }}, t2 AS {{ dbt_semantic_view.sv_source('seed_sources', 'base_table2') }})
+DIMENSIONS(
+  t1.count AS value,
+  t2.volume AS value
+)
+METRICS(
+  t1.total_rows AS SUM(t1.count) COMMENT = $$Total row count aggregate$$
+)

--- a/integration_tests/models/semantic_view_with_primary_key.sql
+++ b/integration_tests/models/semantic_view_with_primary_key.sql
@@ -1,0 +1,8 @@
+{{ config(materialized='semantic_view') }}
+
+TABLES (
+  t1 AS {{ dbt_semantic_view.sv_ref('base_table') }} PRIMARY KEY (id)
+)
+DIMENSIONS(
+  t1.value AS value
+)

--- a/integration_tests/models/semantic_view_with_table_comment_clause.sql
+++ b/integration_tests/models/semantic_view_with_table_comment_clause.sql
@@ -1,0 +1,8 @@
+{{ config(materialized='semantic_view') }}
+
+TABLES (
+  t1 AS {{ dbt_semantic_view.sv_ref('base_table') }} COMMENT = 'Table-level comment on the TABLES entry'
+)
+DIMENSIONS(
+  t1.value AS value
+)

--- a/integration_tests/models/source.yml
+++ b/integration_tests/models/source.yml
@@ -19,4 +19,9 @@ sources:
     schema: "{{ target.schema }}"
     tables:
       - name: base_table2
+        columns:
+          - name: id
+            description: "Row identifier"
+          - name: value
+            description: "Generic numeric value column"
       - name: raw_semantic_view

--- a/integration_tests/models/table_refer_to_raw_semantic_view.sql
+++ b/integration_tests/models/table_refer_to_raw_semantic_view.sql
@@ -15,6 +15,6 @@
 
 {{ config(materialized='table') }}
 
-select * from semantic_view({{ source('seed_sources', 'raw_semantic_view') }} metrics total_rows)
+select * from semantic_view({{ dbt_semantic_view.sv_source('seed_sources', 'raw_semantic_view') }} metrics total_rows)
 
 

--- a/integration_tests/models/table_refer_to_semantic_view.sql
+++ b/integration_tests/models/table_refer_to_semantic_view.sql
@@ -16,6 +16,6 @@
 {{ config(materialized='table') }}
 
 select *
-from semantic_view({{ ref('semantic_view_basic') }} metrics total_rows)
+from semantic_view({{ dbt_semantic_view.sv_ref('semantic_view_basic') }} metrics total_rows)
 
 

--- a/integration_tests/tests/base_table.sql
+++ b/integration_tests/tests/base_table.sql
@@ -13,9 +13,10 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-{{ config(materialized='test') }}
+{{ config(materialized='test', enabled=not flags.EMPTY) }}
 
 -- Passes when the seed has rows; fails if empty
+-- Skipped with --empty because the flag rewrites ref() to return 0 rows by design
 select 'my_seed is empty' as error_message
 where not exists (
   select 1 from {{ ref('my_seed') }}

--- a/integration_tests/tests/semantic_view_basic_has_comment.sql
+++ b/integration_tests/tests/semantic_view_basic_has_comment.sql
@@ -17,6 +17,6 @@
 
 -- Assert the semantic view's DDL contains the configured comment
 select 'semantic view description missing' as error_message
-where position('comment=''test semantic view''' in lower(get_ddl('SEMANTIC_VIEW', '{{ ref('semantic_view_basic') }}'))) = 0
+where position('comment=''test semantic view''' in lower(get_ddl('SEMANTIC_VIEW', '{{ dbt_semantic_view.sv_ref('semantic_view_basic') }}'))) = 0
 
 

--- a/integration_tests/tests/semantic_view_basic_has_no_copy_grants.sql
+++ b/integration_tests/tests/semantic_view_basic_has_no_copy_grants.sql
@@ -18,7 +18,7 @@
 -- Assert COPY GRANTS is absent when not in SQL or yaml
 select 'COPY GRANTS unexpectedly present for SEMANTIC_VIEW_BASIC' as error_message
 where position(
-  'copy grants' in lower(get_ddl('SEMANTIC_VIEW', '{{ ref('semantic_view_basic') }}'))
+  'copy grants' in lower(get_ddl('SEMANTIC_VIEW', '{{ dbt_semantic_view.sv_ref('semantic_view_basic') }}'))
 ) > 0
 
 

--- a/integration_tests/tests/semantic_view_dotted_rhs_has_column_comment.sql
+++ b/integration_tests/tests/semantic_view_dotted_rhs_has_column_comment.sql
@@ -1,0 +1,11 @@
+{{ config(materialized='test') }}
+
+-- Regression test: a DIMENSIONS entry with a qualified (dotted) RHS column
+-- reference must trigger auto-injection just like a bare RHS. Today's line-47
+-- regex rejects dotted RHS; this test locks in the relaxed form.
+with ddl as (
+  select lower(get_ddl('SEMANTIC_VIEW', '{{ dbt_semantic_view.sv_ref('semantic_view_with_dotted_rhs') }}')) as body
+)
+select 'auto-injected description missing for dimension with qualified (dotted) RHS column reference' as error_message
+from ddl
+where position('generic numeric value column' in body) = 0

--- a/integration_tests/tests/semantic_view_mixed_trailing_clauses_has_both_comments.sql
+++ b/integration_tests/tests/semantic_view_mixed_trailing_clauses_has_both_comments.sql
@@ -1,0 +1,15 @@
+{{ config(materialized='test') }}
+
+-- Regression test for multi-entry TABLES combined with trailing per-entry
+-- clauses. Covers UNIQUE + WITH SYNONYMS end-to-end — both dims rely on
+-- auto-injection, so the walker must strip both trailing clauses for the
+-- dot-splitter to identify the correct source tables.
+-- Both base_table.value (models/schema.yml) and base_table2.value (source.yml)
+-- share the description "Generic numeric value column", so we assert the
+-- string appears at least twice: once per successfully-auto-injected dim.
+with ddl as (
+  select lower(get_ddl('SEMANTIC_VIEW', '{{ dbt_semantic_view.sv_ref('semantic_view_with_mixed_trailing_clauses') }}')) as body
+)
+select 'auto-injected description should appear twice (once per dim) but appears fewer than 2 times — walker may have failed to strip UNIQUE or WITH SYNONYMS' as error_message
+from ddl
+where regexp_count(body, 'generic numeric value column') < 2

--- a/integration_tests/tests/semantic_view_persist_docs_has_column_comments.sql
+++ b/integration_tests/tests/semantic_view_persist_docs_has_column_comments.sql
@@ -1,0 +1,24 @@
+{{ config(materialized='test') }}
+
+-- Assert the resolved-from-graph column description appears twice in the
+-- DIMENSIONS clause (once per alias, both resolve to `value` description)
+-- and the explicit description override appears on the METRIC.
+-- Expected description strings are defined in integration_tests/models/schema.yml
+-- (base_table.value) and integration_tests/models/source.yml (base_table2.value);
+-- if those YAMLs change, update the literals below.
+with ddl as (
+  select lower(get_ddl('SEMANTIC_VIEW', '{{ dbt_semantic_view.sv_ref('semantic_view_with_persist_docs') }}')) as body
+),
+checks as (
+  select
+    (length(body) - length(replace(body, 'generic numeric value column', ''))) / length('generic numeric value column') as dim_desc_count,
+    position('total row count aggregate' in body) as metric_desc_pos
+  from ddl
+)
+select error_message from (
+  select 'dimension value-column description not present twice' as error_message, 1 as ord
+  from checks where dim_desc_count < 2
+  union all
+  select 'metric description override missing' as error_message, 2 as ord
+  from checks where metric_desc_pos = 0
+)

--- a/integration_tests/tests/semantic_view_persist_docs_has_relation_comment.sql
+++ b/integration_tests/tests/semantic_view_persist_docs_has_relation_comment.sql
@@ -1,0 +1,9 @@
+{{ config(materialized='test') }}
+
+-- Assert the persist_docs-enabled semantic view's DDL contains the model
+-- description from schema.yml as a top-level COMMENT clause.
+select 'model description missing from semantic_view_with_persist_docs DDL' as error_message
+where position(
+  'semantic view exercising both relation and column persist_docs'
+  in lower(get_ddl('SEMANTIC_VIEW', '{{ dbt_semantic_view.sv_ref('semantic_view_with_persist_docs') }}'))
+) = 0

--- a/integration_tests/tests/semantic_view_persist_docs_skips_inline_relation_comment.sql
+++ b/integration_tests/tests/semantic_view_persist_docs_skips_inline_relation_comment.sql
@@ -1,0 +1,11 @@
+{{ config(materialized='test') }}
+
+-- semantic_view_basic's schema.yml has a description AND persist_docs.relation
+-- is true at the project level, but the model's SQL already writes an inline
+-- COMMENT='test semantic view'. Inline SQL wins: the schema.yml description
+-- must NOT override the inline comment.
+select 'inline COMMENT was overridden by schema.yml description' as error_message
+where position(
+  'comment=''test semantic view'''
+  in lower(get_ddl('SEMANTIC_VIEW', '{{ dbt_semantic_view.sv_ref('semantic_view_basic') }}'))
+) = 0

--- a/integration_tests/tests/semantic_view_primary_key_has_column_comment.sql
+++ b/integration_tests/tests/semantic_view_primary_key_has_column_comment.sql
@@ -1,0 +1,11 @@
+{{ config(materialized='test') }}
+
+-- Regression test for trailing per-entry clauses in TABLES: PRIMARY KEY (...)
+-- must not break auto-injection of column comments on dimensions.
+-- Description comes from integration_tests/models/schema.yml (base_table.value).
+with ddl as (
+  select lower(get_ddl('SEMANTIC_VIEW', '{{ dbt_semantic_view.sv_ref('semantic_view_with_primary_key') }}')) as body
+)
+select 'auto-injected column comment missing from semantic_view_with_primary_key DDL' as error_message
+from ddl
+where position('generic numeric value column' in body) = 0

--- a/integration_tests/tests/semantic_view_sum_matches_base_table.sql
+++ b/integration_tests/tests/semantic_view_sum_matches_base_table.sql
@@ -19,7 +19,7 @@
 with base_sum as (
   select sum(value) as v from {{ ref('base_table') }}
 ), sv as (
-  select * from semantic_view({{ ref('semantic_view_basic') }} metrics total_rows)
+  select * from semantic_view({{ dbt_semantic_view.sv_ref('semantic_view_basic') }} metrics total_rows)
 )
 select 'semantic view metric does not match base_table sum' as error_message
 from base_sum, sv

--- a/integration_tests/tests/semantic_view_table_comment_clause_has_column_comment.sql
+++ b/integration_tests/tests/semantic_view_table_comment_clause_has_column_comment.sql
@@ -1,0 +1,10 @@
+{{ config(materialized='test') }}
+
+-- Regression test: per-entry COMMENT = '...' on a TABLES entry must not
+-- break auto-injection of the column-level description on the dimension.
+with ddl as (
+  select lower(get_ddl('SEMANTIC_VIEW', '{{ dbt_semantic_view.sv_ref('semantic_view_with_table_comment_clause') }}')) as body
+)
+select 'auto-injected column comment missing when TABLES entry carries a COMMENT clause' as error_message
+from ddl
+where position('generic numeric value column' in body) = 0

--- a/integration_tests/tests/semantic_view_with_ca_extension_has_extension.sql
+++ b/integration_tests/tests/semantic_view_with_ca_extension_has_extension.sql
@@ -18,8 +18,8 @@
 -- Assert the CA extension is present with expected values via GET_DDL
 select 'CA extension missing or values mismatch for SEMANTIC_VIEW_WITH_CA_EXTENSION' as error_message
 where not (
-  position('ca' in lower(get_ddl('SEMANTIC_VIEW', '{{ ref('semantic_view_with_ca_extension') }}'))) > 0
-  and position('"verified_queries":[{"name":"hi", "question": "hello"}]' in lower(get_ddl('SEMANTIC_VIEW', '{{ ref('semantic_view_with_ca_extension') }}'))) > 0
+  position('ca' in lower(get_ddl('SEMANTIC_VIEW', '{{ dbt_semantic_view.sv_ref('semantic_view_with_ca_extension') }}'))) > 0
+  and position('"verified_queries":[{"name":"hi", "question": "hello"}]' in lower(get_ddl('SEMANTIC_VIEW', '{{ dbt_semantic_view.sv_ref('semantic_view_with_ca_extension') }}'))) > 0
 )
 
 

--- a/integration_tests/tests/semantic_view_with_copy_has_copy_grants.sql
+++ b/integration_tests/tests/semantic_view_with_copy_has_copy_grants.sql
@@ -18,7 +18,7 @@
 -- Assert COPY GRANTS is present in DDL when specified in SQL
 select 'COPY GRANTS missing for SEMANTIC_VIEW_WITH_COPY_GRANTS' as error_message
 where position(
-  'copy grants' in lower(get_ddl('SEMANTIC_VIEW', '{{ ref('semantic_view_with_copy_grants') }}'))
+  'copy grants' in lower(get_ddl('SEMANTIC_VIEW', '{{ dbt_semantic_view.sv_ref('semantic_view_with_copy_grants') }}'))
 ) = 0
 
 

--- a/integration_tests/tests/table_refer_semantic_view_matches_semantic_view.sql
+++ b/integration_tests/tests/table_refer_semantic_view_matches_semantic_view.sql
@@ -19,7 +19,7 @@
 with table_ref as (
   select * from {{ ref('table_refer_to_semantic_view') }}
 ), sv as (
-  select * from semantic_view({{ ref('semantic_view_basic') }} metrics total_rows)
+  select * from semantic_view({{ dbt_semantic_view.sv_ref('semantic_view_basic') }} metrics total_rows)
 )
 select 'table refer result does not match semantic view result' as error_message
 from table_ref, sv

--- a/macros/materializations/semantic_view.sql
+++ b/macros/materializations/semantic_view.sql
@@ -20,9 +20,6 @@
 
     {% set target_relation = this.incorporate(type='view') %}
 
-    {# TODO: enable persist_docs after semantic_view is supported as a SnowflakeRelationType #}
-    {# {% do persist_docs(target_relation, model, for_columns=false) %} #}
-
     {% do unset_query_tag(original_query_tag) %}
 
     {% do return({'relations': [target_relation]}) %}

--- a/macros/relations/semantic_view/create.sql
+++ b/macros/relations/semantic_view/create.sql
@@ -60,18 +60,22 @@
     COMMENT = $$<comment_text>$$
   to a CREATE OR REPLACE SEMANTIC VIEW statement.
 
-  - If the statement already has a top-level COMMENT = ... clause (after the
-    last closing parenthesis), returns the input unchanged — inline SQL wins.
+  - If the statement already has a top-level COMMENT = ... clause, returns
+    the input unchanged — inline SQL wins.
   - If the statement ends with COPY GRANTS, inserts the COMMENT clause
     BEFORE it so COPY GRANTS remains the final clause (Snowflake grammar).
-  - Relation-level COMMENT can only appear after all clause bodies (after
-    the last ')'), so only the text after the last ')' needs to be scanned.
-    This avoids Jinja's MAX_RANGE sandbox limit on large compiled SQL bodies.
-  - Known limitation: if an existing user-written COMMENT value contains a
-    literal ')', rfind(')') may land inside that value and the check will
-    miss it, causing a duplicate COMMENT append. This edge case is accepted
-    as a regression vs. the prior character-by-character scanner. In practice
-    relation-level COMMENT values rarely contain ')'.
+  - Detects an existing COMMENT clause by scanning all occurrences of 'comment'
+    at top-level (paren depth 0). Works correctly even when AI_VERIFIED_QUERIES(...)
+    or other parenthesized clauses appear after COMMENT.
+  - Known limitation: if a string literal inside a clause body ($$...$$) contains
+    unbalanced parentheses (e.g., $$func(arg$$), the paren-balance depth check may
+    misclassify a COMMENT inside the body as top-level. This edge case is extremely
+    unlikely in Snowflake semantic view DDL.
+  - Known limitation: if a relation-level COMMENT is inserted BEFORE AI_VERIFIED_QUERIES,
+    the new COMMENT clause will still be appended at the end of body (after
+    AI_VERIFIED_QUERIES), violating clause order. This only matters when the model
+    already has no COMMENT and also uses AI_VERIFIED_QUERIES — a rare combination.
+    Acceptable for current use. Fix: detect AI clause positions and insert before them.
   - $ in comment_text is escaped to [$] (Snowflake convention) so the
     description can never close the enclosing $$...$$ block.
 -#}
@@ -94,13 +98,32 @@
     {%- set tail = '' -%}
   {%- endif -%}
 
-  {#- A relation-level COMMENT can only appear after all clause bodies (after last ')').
-      Scan only the tail after the last ')' to detect existing COMMENT. -#}
-  {%- set last_paren = body.rfind(')') -%}
+  {#- Detect existing top-level COMMENT using split + paren-balance.
+      Splits body on 'comment', then for each occurrence checks:
+        (a) the occurrence is followed by \s*= (it's a COMMENT = clause, not just the word)
+        (b) paren count before that position is balanced (it's at depth 0, not inside a body)
+      Uses str.split() + str.count() — O(n) Python ops, NOT subject to Jinja's MAX_RANGE
+      sandbox limit. Correctly handles:
+        - AI_VERIFIED_QUERIES(...) and other post-COMMENT parenthesized clauses (C1)
+        - bodies with no parentheses at all (C2)
+        - per-column COMMENTs inside clause bodies (they are at depth > 0 so ignored)
+  -#}
+  {%- set lower_body = body | lower -%}
   {%- set ns = namespace(has_comment=false) -%}
-  {%- if last_paren != -1 -%}
-    {%- set after_body = body[last_paren + 1:] | lower -%}
-    {%- set ns.has_comment = modules.re.search('\\bcomment\\s*=', after_body) is not none -%}
+  {%- if 'comment' in lower_body -%}
+    {%- set comment_parts = lower_body.split('comment') -%}
+    {%- set pos = namespace(val=0) -%}
+    {%- for part in comment_parts[:-1] -%}
+      {%- if not ns.has_comment -%}
+        {%- set at_comment = pos.val + (part | length) -%}
+        {%- if modules.re.match('comment\\s*=', lower_body[at_comment:]) -%}
+          {%- if body[:at_comment].count('(') == body[:at_comment].count(')') -%}
+            {%- set ns.has_comment = true -%}
+          {%- endif -%}
+        {%- endif -%}
+        {%- set pos.val = at_comment + 7 -%}
+      {%- endif -%}
+    {%- endfor -%}
   {%- endif -%}
 
   {%- set escaped = comment_text | replace('$', '[$]') -%}

--- a/macros/relations/semantic_view/create.sql
+++ b/macros/relations/semantic_view/create.sql
@@ -41,7 +41,7 @@
 
   {# detect existing COPY GRANTS at the end, case/whitespace-insensitive #}
   {%- set tokens = s.split() -%}
-  {%- set ends_with_copy = (tokens | length >= 2) 
+  {%- set ends_with_copy = (tokens | length >= 2)
       and ((tokens[-2] | lower) == 'copy')
       and ((tokens[-1] | lower) == 'grants') -%}
 
@@ -55,6 +55,120 @@
 {%- endmacro %}
 
 
+{#-
+  append_comment_if_missing: idempotently appends
+    COMMENT = $$<comment_text>$$
+  to a CREATE OR REPLACE SEMANTIC VIEW statement.
+
+  - If the statement already has a top-level COMMENT = ... clause (at paren
+    depth 0, outside any string literal), returns the input unchanged --
+    inline SQL wins.
+  - If the statement ends with COPY GRANTS, inserts the COMMENT clause
+    BEFORE it so COPY GRANTS remains the final clause (Snowflake grammar).
+  - Treats '...' and $$...$$ as opaque so a literal COMMENT inside a
+    description never false-matches. A regex would be simpler but cannot
+    track paren depth, which we need to ignore per-dimension COMMENTs.
+  - $ in comment_text is escaped to [$] (Snowflake convention) so the
+    description can never close the enclosing $$...$$ block.
+-#}
+{% macro append_comment_if_missing(sql, comment_text) -%}
+  {%- set s = (sql | trim) -%}
+  {%- if s[-1:] == ';' -%}
+    {%- set s = (s[:-1] | trim) -%}
+  {%- endif -%}
+
+  {%- set tokens = s.split() -%}
+  {%- set ends_with_copy = (tokens | length >= 2)
+      and ((tokens[-2] | lower) == 'copy')
+      and ((tokens[-1] | lower) == 'grants') -%}
+
+  {%- if ends_with_copy -%}
+    {%- set lower_s = s | lower -%}
+    {%- set cg_idx = lower_s.rfind('copy grants') -%}
+    {%- set body = (s[:cg_idx] | trim) -%}
+    {%- set tail = s[cg_idx:] -%}
+  {%- else -%}
+    {%- set body = s -%}
+    {%- set tail = '' -%}
+  {%- endif -%}
+
+  {%- set lower_body = body | lower -%}
+  {%- set ns = namespace(has_comment=false) -%}
+
+  {# Cheap bailout: skip the full scanner when no candidate token exists. #}
+  {%- if 'comment' in lower_body -%}
+    {%- set n = body | length -%}
+    {%- set ns2 = namespace(i=0, depth=0) -%}
+    {%- for _ in range(n) -%}
+      {%- if ns2.i < n and not ns.has_comment -%}
+        {%- set ch = body[ns2.i] -%}
+        {%- if ch == "'" -%}
+          {%- set ns2.i = ns2.i + 1 -%}
+          {%- set closed = namespace(done=false) -%}
+          {%- for _ in range(n - ns2.i) -%}
+            {%- if not closed.done and ns2.i < n -%}
+              {%- if body[ns2.i] == "'" -%}
+                {%- if body[ns2.i + 1:ns2.i + 2] == "'" -%}
+                  {%- set ns2.i = ns2.i + 2 -%}
+                {%- else -%}
+                  {%- set ns2.i = ns2.i + 1 -%}
+                  {%- set closed.done = true -%}
+                {%- endif -%}
+              {%- else -%}
+                {%- set ns2.i = ns2.i + 1 -%}
+              {%- endif -%}
+            {%- endif -%}
+          {%- endfor -%}
+        {%- elif ch == '$' and body[ns2.i + 1:ns2.i + 2] == '$' -%}
+          {%- set ns2.i = ns2.i + 2 -%}
+          {%- set closed = namespace(done=false) -%}
+          {%- for _ in range(n - ns2.i) -%}
+            {%- if not closed.done and ns2.i < n -%}
+              {%- if body[ns2.i] == '$' and body[ns2.i + 1:ns2.i + 2] == '$' -%}
+                {%- set ns2.i = ns2.i + 2 -%}
+                {%- set closed.done = true -%}
+              {%- else -%}
+                {%- set ns2.i = ns2.i + 1 -%}
+              {%- endif -%}
+            {%- endif -%}
+          {%- endfor -%}
+        {%- elif ch == '(' -%}
+          {%- set ns2.depth = ns2.depth + 1 -%}
+          {%- set ns2.i = ns2.i + 1 -%}
+        {%- elif ch == ')' -%}
+          {%- set ns2.depth = ns2.depth - 1 -%}
+          {%- set ns2.i = ns2.i + 1 -%}
+        {%- elif ns2.depth == 0 and lower_body[ns2.i:ns2.i + 7] == 'comment' -%}
+          {%- set after = ns2.i + 7 -%}
+          {%- set prev_char = body[ns2.i - 1:ns2.i] -%}
+          {%- set prev_ok = prev_char == '' or not (prev_char.isalnum() or prev_char == '_') -%}
+          {%- set next_char = body[after:after + 1] -%}
+          {%- set next_ok = next_char == '' or not (next_char.isalnum() or next_char == '_') -%}
+          {%- if prev_ok and next_ok -%}
+            {%- set rest = body[after:] | trim -%}
+            {%- if rest and rest[0] == '=' -%}
+              {%- set ns.has_comment = true -%}
+            {%- endif -%}
+          {%- endif -%}
+          {%- set ns2.i = after -%}
+        {%- else -%}
+          {%- set ns2.i = ns2.i + 1 -%}
+        {%- endif -%}
+      {%- endif -%}
+    {%- endfor -%}
+  {%- endif -%}
+
+  {%- set escaped = comment_text | replace('$', '[$]') -%}
+  {%- if ns.has_comment -%}
+    {{- sql -}}
+  {%- elif ends_with_copy -%}
+    {{- body ~ '\nCOMMENT = $$' ~ escaped ~ '$$\n' ~ tail -}}
+  {%- else -%}
+    {{- body ~ '\nCOMMENT = $$' ~ escaped ~ '$$' -}}
+  {%- endif -%}
+{%- endmacro %}
+
+
 {% macro snowflake__create_or_replace_semantic_view() %}
   {%- set identifier = model['alias'] -%}
 
@@ -64,8 +178,16 @@
       identifier=identifier, schema=schema, database=database,
       type='view') -%}
 
+  {%- if config.persist_column_docs() -%}
+    {%- set sql = dbt_semantic_view.append_column_comments_if_missing(sql) -%}
+  {%- endif -%}
+
   {%- if copy_grants -%}
     {%- set sql = dbt_semantic_view.append_copy_grants_if_missing(sql) -%}
+  {%- endif -%}
+
+  {%- if config.persist_relation_docs() and model.description -%}
+    {%- set sql = dbt_semantic_view.append_comment_if_missing(sql, model.description) -%}
   {%- endif -%}
 
   {{ run_hooks(pre_hooks) }}

--- a/macros/relations/semantic_view/create.sql
+++ b/macros/relations/semantic_view/create.sql
@@ -60,22 +60,24 @@
     COMMENT = $$<comment_text>$$
   to a CREATE OR REPLACE SEMANTIC VIEW statement.
 
-  - If the statement already has a top-level COMMENT = ... clause (at paren
-    depth 0, outside any string literal), returns the input unchanged --
-    inline SQL wins.
+  - If the statement already has a top-level COMMENT = ... clause (after the
+    last closing parenthesis), returns the input unchanged — inline SQL wins.
   - If the statement ends with COPY GRANTS, inserts the COMMENT clause
     BEFORE it so COPY GRANTS remains the final clause (Snowflake grammar).
-  - Treats '...' and $$...$$ as opaque so a literal COMMENT inside a
-    description never false-matches. A regex would be simpler but cannot
-    track paren depth, which we need to ignore per-dimension COMMENTs.
+  - Relation-level COMMENT can only appear after all clause bodies (after
+    the last ')'), so only the text after the last ')' needs to be scanned.
+    This avoids Jinja's MAX_RANGE sandbox limit on large compiled SQL bodies.
+  - Known limitation: if an existing user-written COMMENT value contains a
+    literal ')', rfind(')') may land inside that value and the check will
+    miss it, causing a duplicate COMMENT append. This edge case is accepted
+    as a regression vs. the prior character-by-character scanner. In practice
+    relation-level COMMENT values rarely contain ')'.
   - $ in comment_text is escaped to [$] (Snowflake convention) so the
     description can never close the enclosing $$...$$ block.
 -#}
 {% macro append_comment_if_missing(sql, comment_text) -%}
   {%- set s = (sql | trim) -%}
-  {%- if s[-1:] == ';' -%}
-    {%- set s = (s[:-1] | trim) -%}
-  {%- endif -%}
+  {%- if s[-1:] == ';' -%}{%- set s = (s[:-1] | trim) -%}{%- endif -%}
 
   {%- set tokens = s.split() -%}
   {%- set ends_with_copy = (tokens | length >= 2)
@@ -92,70 +94,13 @@
     {%- set tail = '' -%}
   {%- endif -%}
 
-  {%- set lower_body = body | lower -%}
+  {#- A relation-level COMMENT can only appear after all clause bodies (after last ')').
+      Scan only the tail after the last ')' to detect existing COMMENT. -#}
+  {%- set last_paren = body.rfind(')') -%}
   {%- set ns = namespace(has_comment=false) -%}
-
-  {# Cheap bailout: skip the full scanner when no candidate token exists. #}
-  {%- if 'comment' in lower_body -%}
-    {%- set n = body | length -%}
-    {%- set ns2 = namespace(i=0, depth=0) -%}
-    {%- for _ in range(n) -%}
-      {%- if ns2.i < n and not ns.has_comment -%}
-        {%- set ch = body[ns2.i] -%}
-        {%- if ch == "'" -%}
-          {%- set ns2.i = ns2.i + 1 -%}
-          {%- set closed = namespace(done=false) -%}
-          {%- for _ in range(n - ns2.i) -%}
-            {%- if not closed.done and ns2.i < n -%}
-              {%- if body[ns2.i] == "'" -%}
-                {%- if body[ns2.i + 1:ns2.i + 2] == "'" -%}
-                  {%- set ns2.i = ns2.i + 2 -%}
-                {%- else -%}
-                  {%- set ns2.i = ns2.i + 1 -%}
-                  {%- set closed.done = true -%}
-                {%- endif -%}
-              {%- else -%}
-                {%- set ns2.i = ns2.i + 1 -%}
-              {%- endif -%}
-            {%- endif -%}
-          {%- endfor -%}
-        {%- elif ch == '$' and body[ns2.i + 1:ns2.i + 2] == '$' -%}
-          {%- set ns2.i = ns2.i + 2 -%}
-          {%- set closed = namespace(done=false) -%}
-          {%- for _ in range(n - ns2.i) -%}
-            {%- if not closed.done and ns2.i < n -%}
-              {%- if body[ns2.i] == '$' and body[ns2.i + 1:ns2.i + 2] == '$' -%}
-                {%- set ns2.i = ns2.i + 2 -%}
-                {%- set closed.done = true -%}
-              {%- else -%}
-                {%- set ns2.i = ns2.i + 1 -%}
-              {%- endif -%}
-            {%- endif -%}
-          {%- endfor -%}
-        {%- elif ch == '(' -%}
-          {%- set ns2.depth = ns2.depth + 1 -%}
-          {%- set ns2.i = ns2.i + 1 -%}
-        {%- elif ch == ')' -%}
-          {%- set ns2.depth = ns2.depth - 1 -%}
-          {%- set ns2.i = ns2.i + 1 -%}
-        {%- elif ns2.depth == 0 and lower_body[ns2.i:ns2.i + 7] == 'comment' -%}
-          {%- set after = ns2.i + 7 -%}
-          {%- set prev_char = body[ns2.i - 1:ns2.i] -%}
-          {%- set prev_ok = prev_char == '' or not (prev_char.isalnum() or prev_char == '_') -%}
-          {%- set next_char = body[after:after + 1] -%}
-          {%- set next_ok = next_char == '' or not (next_char.isalnum() or next_char == '_') -%}
-          {%- if prev_ok and next_ok -%}
-            {%- set rest = body[after:] | trim -%}
-            {%- if rest and rest[0] == '=' -%}
-              {%- set ns.has_comment = true -%}
-            {%- endif -%}
-          {%- endif -%}
-          {%- set ns2.i = after -%}
-        {%- else -%}
-          {%- set ns2.i = ns2.i + 1 -%}
-        {%- endif -%}
-      {%- endif -%}
-    {%- endfor -%}
+  {%- if last_paren != -1 -%}
+    {%- set after_body = body[last_paren + 1:] | lower -%}
+    {%- set ns.has_comment = modules.re.search('\\bcomment\\s*=', after_body) is not none -%}
   {%- endif -%}
 
   {%- set escaped = comment_text | replace('$', '[$]') -%}

--- a/macros/relations/semantic_view/persist_column_comments.sql
+++ b/macros/relations/semantic_view/persist_column_comments.sql
@@ -14,7 +14,12 @@
   passthrough — there is no single column to look up.
 
   Limitations:
-  - SQL comments inside body (-- or /* */) are not handled as opaque regions.
+  - SQL comments inside the semantic view body (-- or /* */) are not handled as
+    opaque regions. A single quote inside a SQL comment (e.g., -- it's a note)
+    will be treated as the start of a string literal, potentially causing
+    _sv_find_clause to skip over the actual clause. Column comments for the
+    affected clause will be silently skipped. Workaround: avoid -- and /* */
+    comments inside semantic view model SQL bodies.
   - RELATIONSHIPS entries are not processed.
   - Model-local columns: in the semantic view's own schema.yml are not used as
     an override source.
@@ -167,7 +172,9 @@
                 {%- endif -%}
               {%- endif -%}
             {%- endfor -%}
-            {%- set ns.skip_until = sql | length -%}
+            {%- if ns.found -%}
+              {%- set ns.skip_until = sql | length -%}
+            {%- endif -%}
           {%- endif -%}
         {%- endif -%}
 

--- a/macros/relations/semantic_view/persist_column_comments.sql
+++ b/macros/relations/semantic_view/persist_column_comments.sql
@@ -613,6 +613,14 @@
   `name` is a final fallback for edge cases. Sources have no `.alias`
   and populate `.identifier`.
 
+  Tiered lookup:
+    Tier 1: strict (database, schema, identifier) match against graph.nodes.
+    Tier 2: strict (database, schema, identifier) match against graph.sources (if Tier 1 found nothing).
+    Tier 3: identifier-only match against graph.nodes (if Tier 2 found nothing). This handles cross-env
+            sv_ref references where the resolved table lives in a different database than the one recorded in graph.nodes.
+            Sources are excluded from this tier because source identifiers are not unique within a project (the same table name can appear
+            across multiple schemas), whereas model names are unique by convention.
+
   Returns the raw description string (may be empty). Caller decides
   whether to emit a COMMENT clause.
 -#}
@@ -643,6 +651,22 @@
             and (src.schema or '') | lower == target_schema
             and (physical | lower) == target_identifier -%}
           {%- set found.node = src -%}
+        {%- endif -%}
+      {%- endif -%}
+    {%- endfor -%}
+  {%- endif -%}
+
+  {#- Tier 3: identifier-only fallback on graph.nodes for cross-env sv_ref scenarios where the
+      resolved table lives in a
+      different database than the one recorded in graph.nodes.
+      Sources are intentionally excluded: source identifiers are not unique within a project and
+      an identifier-only match against graph.sources risks returning the wrong node. -#}
+  {%- if found.node is none -%}
+    {%- for node in graph.nodes.values() -%}
+      {%- if found.node is none -%}
+        {%- set physical = node.alias or node.identifier or node.name -%}
+        {%- if physical and (physical | lower) == target_identifier -%}
+          {%- set found.node = node -%}
         {%- endif -%}
       {%- endif -%}
     {%- endfor -%}

--- a/macros/relations/semantic_view/persist_column_comments.sql
+++ b/macros/relations/semantic_view/persist_column_comments.sql
@@ -1,0 +1,667 @@
+{#-
+  append_column_comments_if_missing(sql)
+
+  Post-processor that auto-injects COMMENT = $$…$$ into semantic view bodies
+  when config.persist_docs.columns is true. Users write plain Snowflake
+  semantic-view SQL; this macro scans each DIMENSIONS/METRICS/FACTS entry and,
+  when the RHS of AS is a single column reference (either a bare identifier
+  like `value` or a qualified form like `t1.value`) and the LHS is
+  alias-qualified, looks up the column description from schema.yml/source.yml
+  and appends the COMMENT clause. The column name used for the lookup is the
+  trailing identifier on the RHS; any qualifying prefix is ignored. Entries
+  that already have an inline COMMENT = … are left untouched (inline wins).
+  Computed expressions (aggregates, arithmetic, function calls, etc.) stay
+  passthrough — there is no single column to look up.
+
+  Limitations:
+  - SQL comments inside body (-- or /* */) are not handled as opaque regions.
+  - RELATIONSHIPS entries are not processed.
+  - Model-local columns: in the semantic view's own schema.yml are not used as
+    an override source.
+  - Cross-table qualified RHS (e.g. `t1.my_dim AS t2.col`) resolves the source
+    table from the LHS alias, not the RHS prefix. If `col` only lives in t2's
+    table, the lookup silently misses. Acceptable because this form is unusual
+    and the regular `t1.my_dim AS t1.col` / `t1.my_dim AS col` cases work.
+-#}
+{% macro append_column_comments_if_missing(sql) -%}
+  {%- if not config.persist_column_docs() -%}
+    {{- sql -}}
+  {%- else -%}
+    {%- set tables_clause = dbt_semantic_view._sv_find_clause(sql, 'TABLES') -%}
+    {%- if not tables_clause.found -%}
+      {{- sql -}}
+    {%- else -%}
+      {%- set tables_body = sql[tables_clause.open_idx + 1 : tables_clause.close_idx] -%}
+      {%- set tables_map = dbt_semantic_view._sv_parse_tables(tables_body) -%}
+      {%- if not tables_map -%}
+        {{- sql -}}
+      {%- else -%}
+        {%- set ns = namespace(out=sql) -%}
+        {%- for keyword in ['DIMENSIONS', 'METRICS', 'FACTS'] -%}
+          {%- set clause = dbt_semantic_view._sv_find_clause(ns.out, keyword) -%}
+          {%- if clause.found -%}
+            {%- set body = ns.out[clause.open_idx + 1 : clause.close_idx] -%}
+            {%- set entries = dbt_semantic_view._sv_split_depth0(body) -%}
+            {%- set new_entries = [] -%}
+            {%- for entry in entries -%}
+              {%- set trimmed = entry | trim -%}
+              {%- if dbt_semantic_view._sv_entry_has_comment(trimmed) -%}
+                {%- do new_entries.append(trimmed) -%}
+              {%- else -%}
+                {%- set split = dbt_semantic_view._sv_split_as(trimmed) -%}
+                {%- if split is none -%}
+                  {%- do new_entries.append(trimmed) -%}
+                {%- else -%}
+                  {#-
+                    Accept either a bare identifier (`value`) or a two-segment
+                    qualified column reference (`t1.value`). The optional prefix
+                    is non-capturing so group(1) is always the trailing column
+                    name — the key used for the description lookup.
+                  -#}
+                  {%- set rhs_match = modules.re.match('^(?:[A-Za-z_][A-Za-z0-9_]*\\.)?([A-Za-z_][A-Za-z0-9_]*)$', split.rhs | trim) -%}
+                  {%- if not rhs_match -%}
+                    {%- do new_entries.append(trimmed) -%}
+                  {%- else -%}
+                    {%- set alias_match = modules.re.match('^\\s*([A-Za-z_][A-Za-z0-9_]*)\\.', split.lhs) -%}
+                    {%- if not alias_match -%}
+                      {%- do new_entries.append(trimmed) -%}
+                    {%- else -%}
+                      {%- set tuple3 = tables_map.get(alias_match.group(1) | lower) -%}
+                      {%- if tuple3 is none -%}
+                        {%- do new_entries.append(trimmed) -%}
+                      {%- else -%}
+                        {%- set desc = dbt_semantic_view._sv_find_column_description(tuple3, rhs_match.group(1)) -%}
+                        {%- if not desc or desc | trim | length == 0 -%}
+                          {%- do new_entries.append(trimmed) -%}
+                        {%- else -%}
+                          {%- set escaped = desc | replace('$', '[$]') -%}
+                          {%- do new_entries.append(trimmed ~ ' COMMENT = $$' ~ escaped ~ '$$') -%}
+                        {%- endif -%}
+                      {%- endif -%}
+                    {%- endif -%}
+                  {%- endif -%}
+                {%- endif -%}
+              {%- endif -%}
+            {%- endfor -%}
+            {%- set new_body = new_entries | join(',\n  ') -%}
+            {%- set ns.out = ns.out[:clause.open_idx + 1] ~ new_body ~ ns.out[clause.close_idx:] -%}
+          {%- endif -%}
+        {%- endfor -%}
+        {{- ns.out -}}
+      {%- endif -%}
+    {%- endif -%}
+  {%- endif -%}
+{%- endmacro %}
+
+
+{#-
+  _sv_find_clause(sql, keyword)
+
+  Character-by-character walk with opaque regions for '...' and $$...$$
+  and paren depth tracking. At paren depth 0, looks for `keyword` with
+  word-boundary checks on both sides. After the keyword match, skips
+  whitespace and expects an opening `(`, then walks to the matching `)`.
+
+  Returns a dict: {found, open_idx, close_idx}
+    - found: bool
+    - open_idx: index of the `(` after keyword (or -1)
+    - close_idx: index of the matching `)` (or -1)
+-#}
+{% macro _sv_find_clause(sql, keyword) -%}
+  {%- set n = sql | length -%}
+  {%- set kw_lower = keyword | lower -%}
+  {%- set kw_len = keyword | length -%}
+  {%- set lower_sql = sql | lower -%}
+  {%- set ns = namespace(i=0, depth=0, found=false, open_idx=-1, close_idx=-1) -%}
+
+  {%- for _ in range(n) -%}
+    {%- if ns.i < n and not ns.found -%}
+      {%- set ch = sql[ns.i] -%}
+
+      {#- Single-quoted string: skip contents, '' is an escaped quote -#}
+      {%- if ch == "'" -%}
+        {%- set ns.i = ns.i + 1 -%}
+        {%- set inner = namespace(done=false) -%}
+        {%- for _ in range(n - ns.i) -%}
+          {%- if not inner.done and ns.i < n -%}
+            {%- if sql[ns.i] == "'" -%}
+              {%- if sql[ns.i + 1:ns.i + 2] == "'" -%}
+                {%- set ns.i = ns.i + 2 -%}
+              {%- else -%}
+                {%- set ns.i = ns.i + 1 -%}
+                {%- set inner.done = true -%}
+              {%- endif -%}
+            {%- else -%}
+              {%- set ns.i = ns.i + 1 -%}
+            {%- endif -%}
+          {%- endif -%}
+        {%- endfor -%}
+
+      {#- Dollar-quoted string: skip contents -#}
+      {%- elif ch == '$' and sql[ns.i + 1:ns.i + 2] == '$' -%}
+        {%- set ns.i = ns.i + 2 -%}
+        {%- set inner = namespace(done=false) -%}
+        {%- for _ in range(n - ns.i) -%}
+          {%- if not inner.done and ns.i < n -%}
+            {%- if sql[ns.i] == '$' and sql[ns.i + 1:ns.i + 2] == '$' -%}
+              {%- set ns.i = ns.i + 2 -%}
+              {%- set inner.done = true -%}
+            {%- else -%}
+              {%- set ns.i = ns.i + 1 -%}
+            {%- endif -%}
+          {%- endif -%}
+        {%- endfor -%}
+
+      {%- elif ch == '(' -%}
+        {%- set ns.depth = ns.depth + 1 -%}
+        {%- set ns.i = ns.i + 1 -%}
+
+      {%- elif ch == ')' -%}
+        {%- set ns.depth = ns.depth - 1 -%}
+        {%- set ns.i = ns.i + 1 -%}
+
+      {#- At depth 0, check for keyword with word-boundary guards -#}
+      {%- elif ns.depth == 0 and lower_sql[ns.i:ns.i + kw_len] == kw_lower -%}
+        {%- set prev_char = sql[ns.i - 1:ns.i] -%}
+        {%- set prev_ok = prev_char == '' or not (prev_char.isalnum() or prev_char == '_') -%}
+        {%- set after_pos = ns.i + kw_len -%}
+        {%- set next_char = sql[after_pos:after_pos + 1] -%}
+        {%- set next_ok = next_char == '' or not (next_char.isalnum() or next_char == '_') -%}
+        {%- if prev_ok and next_ok -%}
+          {%- set ns.i = after_pos -%}
+          {#- Skip whitespace to find the ( -#}
+          {%- set ws = namespace(done=false) -%}
+          {%- for _ in range(n - ns.i) -%}
+            {%- if not ws.done and ns.i < n -%}
+              {%- if sql[ns.i] in [' ', '\t', '\n', '\r'] -%}
+                {%- set ns.i = ns.i + 1 -%}
+              {%- else -%}
+                {%- set ws.done = true -%}
+              {%- endif -%}
+            {%- endif -%}
+          {%- endfor -%}
+          {%- if ns.i < n and sql[ns.i] == '(' -%}
+            {%- set ns.open_idx = ns.i -%}
+            {%- set ns.i = ns.i + 1 -%}
+            {#- Walk to the matching ) tracking depth from 1 -#}
+            {%- set depth_inner = namespace(d=1, done=false) -%}
+            {%- for _ in range(n - ns.i) -%}
+              {%- if not depth_inner.done and ns.i < n -%}
+                {%- set ic = sql[ns.i] -%}
+                {%- if ic == "'" -%}
+                  {%- set ns.i = ns.i + 1 -%}
+                  {%- set qi = namespace(done=false) -%}
+                  {%- for _ in range(n - ns.i) -%}
+                    {%- if not qi.done and ns.i < n -%}
+                      {%- if sql[ns.i] == "'" -%}
+                        {%- if sql[ns.i + 1:ns.i + 2] == "'" -%}
+                          {%- set ns.i = ns.i + 2 -%}
+                        {%- else -%}
+                          {%- set ns.i = ns.i + 1 -%}
+                          {%- set qi.done = true -%}
+                        {%- endif -%}
+                      {%- else -%}
+                        {%- set ns.i = ns.i + 1 -%}
+                      {%- endif -%}
+                    {%- endif -%}
+                  {%- endfor -%}
+                {%- elif ic == '$' and sql[ns.i + 1:ns.i + 2] == '$' -%}
+                  {%- set ns.i = ns.i + 2 -%}
+                  {%- set qi = namespace(done=false) -%}
+                  {%- for _ in range(n - ns.i) -%}
+                    {%- if not qi.done and ns.i < n -%}
+                      {%- if sql[ns.i] == '$' and sql[ns.i + 1:ns.i + 2] == '$' -%}
+                        {%- set ns.i = ns.i + 2 -%}
+                        {%- set qi.done = true -%}
+                      {%- else -%}
+                        {%- set ns.i = ns.i + 1 -%}
+                      {%- endif -%}
+                    {%- endif -%}
+                  {%- endfor -%}
+                {%- elif ic == '(' -%}
+                  {%- set depth_inner.d = depth_inner.d + 1 -%}
+                  {%- set ns.i = ns.i + 1 -%}
+                {%- elif ic == ')' -%}
+                  {%- set depth_inner.d = depth_inner.d - 1 -%}
+                  {%- if depth_inner.d == 0 -%}
+                    {%- set ns.close_idx = ns.i -%}
+                    {%- set ns.found = true -%}
+                    {%- set depth_inner.done = true -%}
+                  {%- endif -%}
+                  {%- set ns.i = ns.i + 1 -%}
+                {%- else -%}
+                  {%- set ns.i = ns.i + 1 -%}
+                {%- endif -%}
+              {%- endif -%}
+            {%- endfor -%}
+          {%- else -%}
+            {%- set ns.i = ns.i + 1 -%}
+          {%- endif -%}
+        {%- else -%}
+          {%- set ns.i = ns.i + 1 -%}
+        {%- endif -%}
+
+      {%- else -%}
+        {%- set ns.i = ns.i + 1 -%}
+      {%- endif -%}
+    {%- endif -%}
+  {%- endfor -%}
+
+  {%- do return({'found': ns.found, 'open_idx': ns.open_idx, 'close_idx': ns.close_idx}) -%}
+{%- endmacro %}
+
+
+{#-
+  _sv_split_depth0(body)
+
+  Splits `body` on commas at paren depth 0, outside '...' and $$...$$
+  regions. Returns a list of entry strings.
+-#}
+{% macro _sv_split_depth0(body) -%}
+  {%- set n = body | length -%}
+  {%- set ns = namespace(i=0, depth=0, current='') -%}
+  {%- set entries = [] -%}
+
+  {%- for _ in range(n) -%}
+    {%- if ns.i < n -%}
+      {%- set ch = body[ns.i] -%}
+
+      {%- if ch == "'" -%}
+        {%- set ns.current = ns.current ~ ch -%}
+        {%- set ns.i = ns.i + 1 -%}
+        {%- set inner = namespace(done=false) -%}
+        {%- for _ in range(n - ns.i) -%}
+          {%- if not inner.done and ns.i < n -%}
+            {%- if body[ns.i] == "'" -%}
+              {%- if body[ns.i + 1:ns.i + 2] == "'" -%}
+                {%- set ns.current = ns.current ~ "''" -%}
+                {%- set ns.i = ns.i + 2 -%}
+              {%- else -%}
+                {%- set ns.current = ns.current ~ "'" -%}
+                {%- set ns.i = ns.i + 1 -%}
+                {%- set inner.done = true -%}
+              {%- endif -%}
+            {%- else -%}
+              {%- set ns.current = ns.current ~ body[ns.i] -%}
+              {%- set ns.i = ns.i + 1 -%}
+            {%- endif -%}
+          {%- endif -%}
+        {%- endfor -%}
+
+      {%- elif ch == '$' and body[ns.i + 1:ns.i + 2] == '$' -%}
+        {%- set ns.current = ns.current ~ '$$' -%}
+        {%- set ns.i = ns.i + 2 -%}
+        {%- set inner = namespace(done=false) -%}
+        {%- for _ in range(n - ns.i) -%}
+          {%- if not inner.done and ns.i < n -%}
+            {%- if body[ns.i] == '$' and body[ns.i + 1:ns.i + 2] == '$' -%}
+              {%- set ns.current = ns.current ~ '$$' -%}
+              {%- set ns.i = ns.i + 2 -%}
+              {%- set inner.done = true -%}
+            {%- else -%}
+              {%- set ns.current = ns.current ~ body[ns.i] -%}
+              {%- set ns.i = ns.i + 1 -%}
+            {%- endif -%}
+          {%- endif -%}
+        {%- endfor -%}
+
+      {%- elif ch == '(' -%}
+        {%- set ns.depth = ns.depth + 1 -%}
+        {%- set ns.current = ns.current ~ ch -%}
+        {%- set ns.i = ns.i + 1 -%}
+
+      {%- elif ch == ')' -%}
+        {%- set ns.depth = ns.depth - 1 -%}
+        {%- set ns.current = ns.current ~ ch -%}
+        {%- set ns.i = ns.i + 1 -%}
+
+      {%- elif ch == ',' and ns.depth == 0 -%}
+        {%- do entries.append(ns.current) -%}
+        {%- set ns.current = '' -%}
+        {%- set ns.i = ns.i + 1 -%}
+
+      {%- else -%}
+        {%- set ns.current = ns.current ~ ch -%}
+        {%- set ns.i = ns.i + 1 -%}
+      {%- endif -%}
+    {%- endif -%}
+  {%- endfor -%}
+
+  {%- if ns.current | trim | length > 0 -%}
+    {%- do entries.append(ns.current) -%}
+  {%- endif -%}
+
+  {%- do return(entries) -%}
+{%- endmacro %}
+
+
+{#-
+  _sv_entry_has_comment(entry)
+
+  Returns true if `entry` contains a top-level COMMENT = token (at paren
+  depth 0, outside all opaque regions), with word-boundary guards on both
+  sides of COMMENT.
+-#}
+{% macro _sv_entry_has_comment(entry) -%}
+  {%- set n = entry | length -%}
+  {%- set lower_entry = entry | lower -%}
+  {%- set ns = namespace(i=0, depth=0, has_comment=false) -%}
+
+  {%- if 'comment' in lower_entry -%}
+    {%- for _ in range(n) -%}
+      {%- if ns.i < n and not ns.has_comment -%}
+        {%- set ch = entry[ns.i] -%}
+
+        {%- if ch == "'" -%}
+          {%- set ns.i = ns.i + 1 -%}
+          {%- set inner = namespace(done=false) -%}
+          {%- for _ in range(n - ns.i) -%}
+            {%- if not inner.done and ns.i < n -%}
+              {%- if entry[ns.i] == "'" -%}
+                {%- if entry[ns.i + 1:ns.i + 2] == "'" -%}
+                  {%- set ns.i = ns.i + 2 -%}
+                {%- else -%}
+                  {%- set ns.i = ns.i + 1 -%}
+                  {%- set inner.done = true -%}
+                {%- endif -%}
+              {%- else -%}
+                {%- set ns.i = ns.i + 1 -%}
+              {%- endif -%}
+            {%- endif -%}
+          {%- endfor -%}
+
+        {%- elif ch == '$' and entry[ns.i + 1:ns.i + 2] == '$' -%}
+          {%- set ns.i = ns.i + 2 -%}
+          {%- set inner = namespace(done=false) -%}
+          {%- for _ in range(n - ns.i) -%}
+            {%- if not inner.done and ns.i < n -%}
+              {%- if entry[ns.i] == '$' and entry[ns.i + 1:ns.i + 2] == '$' -%}
+                {%- set ns.i = ns.i + 2 -%}
+                {%- set inner.done = true -%}
+              {%- else -%}
+                {%- set ns.i = ns.i + 1 -%}
+              {%- endif -%}
+            {%- endif -%}
+          {%- endfor -%}
+
+        {%- elif ch == '(' -%}
+          {%- set ns.depth = ns.depth + 1 -%}
+          {%- set ns.i = ns.i + 1 -%}
+
+        {%- elif ch == ')' -%}
+          {%- set ns.depth = ns.depth - 1 -%}
+          {%- set ns.i = ns.i + 1 -%}
+
+        {%- elif ns.depth == 0 and lower_entry[ns.i:ns.i + 7] == 'comment' -%}
+          {%- set prev_char = entry[ns.i - 1:ns.i] -%}
+          {%- set prev_ok = prev_char == '' or not (prev_char.isalnum() or prev_char == '_') -%}
+          {%- set after_pos = ns.i + 7 -%}
+          {%- set next_char = entry[after_pos:after_pos + 1] -%}
+          {%- set next_ok = next_char == '' or not (next_char.isalnum() or next_char == '_') -%}
+          {%- if prev_ok and next_ok -%}
+            {%- set rest = entry[after_pos:] | trim -%}
+            {%- if rest and rest[0] == '=' -%}
+              {%- set ns.has_comment = true -%}
+            {%- endif -%}
+          {%- endif -%}
+          {%- set ns.i = after_pos -%}
+
+        {%- else -%}
+          {%- set ns.i = ns.i + 1 -%}
+        {%- endif -%}
+      {%- endif -%}
+    {%- endfor -%}
+  {%- endif -%}
+
+  {%- do return(ns.has_comment) -%}
+{%- endmacro %}
+
+
+{#-
+  _sv_split_as(entry)
+
+  Splits on the first case-insensitive ` AS ` token at top-level (depth 0,
+  outside opaque regions). Returns a dict {lhs, rhs} or none if no split found.
+-#}
+{% macro _sv_split_as(entry) -%}
+  {%- set n = entry | length -%}
+  {%- set lower_entry = entry | lower -%}
+  {%- set ns = namespace(i=0, depth=0, split_pos=-1) -%}
+
+  {%- for _ in range(n) -%}
+    {%- if ns.i < n and ns.split_pos == -1 -%}
+      {%- set ch = entry[ns.i] -%}
+
+      {%- if ch == "'" -%}
+        {%- set ns.i = ns.i + 1 -%}
+        {%- set inner = namespace(done=false) -%}
+        {%- for _ in range(n - ns.i) -%}
+          {%- if not inner.done and ns.i < n -%}
+            {%- if entry[ns.i] == "'" -%}
+              {%- if entry[ns.i + 1:ns.i + 2] == "'" -%}
+                {%- set ns.i = ns.i + 2 -%}
+              {%- else -%}
+                {%- set ns.i = ns.i + 1 -%}
+                {%- set inner.done = true -%}
+              {%- endif -%}
+            {%- else -%}
+              {%- set ns.i = ns.i + 1 -%}
+            {%- endif -%}
+          {%- endif -%}
+        {%- endfor -%}
+
+      {%- elif ch == '$' and entry[ns.i + 1:ns.i + 2] == '$' -%}
+        {%- set ns.i = ns.i + 2 -%}
+        {%- set inner = namespace(done=false) -%}
+        {%- for _ in range(n - ns.i) -%}
+          {%- if not inner.done and ns.i < n -%}
+            {%- if entry[ns.i] == '$' and entry[ns.i + 1:ns.i + 2] == '$' -%}
+              {%- set ns.i = ns.i + 2 -%}
+              {%- set inner.done = true -%}
+            {%- else -%}
+              {%- set ns.i = ns.i + 1 -%}
+            {%- endif -%}
+          {%- endif -%}
+        {%- endfor -%}
+
+      {%- elif ch == '(' -%}
+        {%- set ns.depth = ns.depth + 1 -%}
+        {%- set ns.i = ns.i + 1 -%}
+
+      {%- elif ch == ')' -%}
+        {%- set ns.depth = ns.depth - 1 -%}
+        {%- set ns.i = ns.i + 1 -%}
+
+      {#-
+        At depth 0 look for whitespace + AS + whitespace (case-insensitive).
+        We need the character before the current position to be whitespace/boundary
+        and the sequence [whitespace]AS[whitespace] starting here.
+        More practically: look for ' as ' as a 4+ char sequence where:
+          entry[i] is whitespace, entry[i+1:i+3] is 'as', entry[i+3] is whitespace.
+      -#}
+      {%- elif ns.depth == 0 and ch in [' ', '\t', '\n', '\r'] -%}
+        {%- set remaining = lower_entry[ns.i:] -%}
+        {%- set as_match = modules.re.match('^(\\s+)[Aa][Ss](\\s+)', remaining) -%}
+        {%- if as_match -%}
+          {%- set token_start = ns.i -%}
+          {%- set skip = as_match.group(0) | length -%}
+          {%- set ns.split_pos = token_start -%}
+          {%- set ns.i = ns.i + skip -%}
+        {%- else -%}
+          {%- set ns.i = ns.i + 1 -%}
+        {%- endif -%}
+
+      {%- else -%}
+        {%- set ns.i = ns.i + 1 -%}
+      {%- endif -%}
+    {%- endif -%}
+  {%- endfor -%}
+
+  {%- if ns.split_pos == -1 -%}
+    {%- do return(none) -%}
+  {%- else -%}
+    {%- set lhs = entry[:ns.split_pos] -%}
+    {%- set rhs = entry[ns.i:] -%}
+    {%- do return({'lhs': lhs, 'rhs': rhs}) -%}
+  {%- endif -%}
+{%- endmacro %}
+
+
+{#-
+  _sv_parse_tables(body)
+
+  Parses the TABLES clause body into a dict of {alias_lower: (db, schema, identifier)}.
+  For each entry:
+    1. Splits on ' AS ' via _sv_split_as -> alias, relation_str.
+    2. Parses relation_str as a dotted identifier (splits on . outside quotes).
+    3. Requires exactly 3 parts -> (db, schema, identifier), all lowercased.
+    4. Strips surrounding "..." from each part.
+  Returns the mapping dict (may be empty if no valid entries found).
+-#}
+{% macro _sv_parse_tables(body) -%}
+  {%- set entries = dbt_semantic_view._sv_split_depth0(body) -%}
+  {%- set result = {} -%}
+
+  {%- for entry in entries -%}
+    {%- set trimmed = entry | trim -%}
+    {%- set split = dbt_semantic_view._sv_split_as(trimmed) -%}
+    {%- if split is not none -%}
+      {%- set alias_lower = split.lhs | trim | lower -%}
+      {%- set relation_str = split.rhs | trim -%}
+
+      {#-
+        Truncate at the first whitespace.
+        Snowflake allows trailing per-TABLES-entry clauses after the dotted name:
+        PRIMARY KEY (...), UNIQUE (...), WITH SYNONYMS (...), COMMENT = '...'.
+        None of those are part of the identifier; strip them before dot-splitting.
+      -#}
+      {%- set tn = relation_str | length -%}
+      {%- set tns = namespace(i=0, stop=-1) -%}
+      {%- for _ in range(tn) -%}
+        {%- if tns.i < tn and tns.stop == -1 -%}
+          {%- set tc = relation_str[tns.i] -%}
+          {%- if tc in [' ', '\t', '\n', '\r'] -%}
+            {%- set tns.stop = tns.i -%}
+          {%- else -%}
+            {%- set tns.i = tns.i + 1 -%}
+          {%- endif -%}
+        {%- endif -%}
+      {%- endfor -%}
+      {%- if tns.stop != -1 -%}
+        {%- set relation_str = relation_str[:tns.stop] -%}
+      {%- endif -%}
+
+      {#- Split relation_str on dots -#}
+      {%- set rn = relation_str | length -%}
+      {%- set rns = namespace(i=0, current='') -%}
+      {%- set parts = [] -%}
+
+      {%- for _ in range(rn) -%}
+        {%- if rns.i < rn -%}
+          {%- set rc = relation_str[rns.i] -%}
+
+          {%- if rc == '.' -%}
+            {%- do parts.append(rns.current) -%}
+            {%- set rns.current = '' -%}
+            {%- set rns.i = rns.i + 1 -%}
+
+          {%- else -%}
+            {%- set rns.current = rns.current ~ rc -%}
+            {%- set rns.i = rns.i + 1 -%}
+          {%- endif -%}
+        {%- endif -%}
+      {%- endfor -%}
+      {%- if rns.current | length > 0 -%}
+        {%- do parts.append(rns.current) -%}
+      {%- endif -%}
+
+      {%- if parts | length == 3 -%}
+        {%- set db_raw = parts[0] | trim -%}
+        {%- set schema_raw = parts[1] | trim -%}
+        {%- set ident_raw = parts[2] | trim -%}
+
+        {#- Strip surrounding double-quotes -#}
+        {%- if db_raw[:1] == '"' and db_raw[-1:] == '"' -%}
+          {%- set db_raw = db_raw[1:-1] | replace('""', '"') -%}
+        {%- endif -%}
+        {%- if schema_raw[:1] == '"' and schema_raw[-1:] == '"' -%}
+          {%- set schema_raw = schema_raw[1:-1] | replace('""', '"') -%}
+        {%- endif -%}
+        {%- if ident_raw[:1] == '"' and ident_raw[-1:] == '"' -%}
+          {%- set ident_raw = ident_raw[1:-1] | replace('""', '"') -%}
+        {%- endif -%}
+
+        {%- do result.update({alias_lower: (db_raw | lower, schema_raw | lower, ident_raw | lower)}) -%}
+      {%- endif -%}
+    {%- endif -%}
+  {%- endfor -%}
+
+  {%- do return(result) -%}
+{%- endmacro %}
+
+
+{#-
+  _sv_find_column_description(tuple3, column_name)
+
+  Walks the dbt manifest to resolve a column's description. Takes a (db, schema,
+  identifier) tuple (all already lowercased) instead of a Relation object.
+  Matches (database, schema, physical_name) case-insensitively against
+  graph.nodes and graph.sources.
+
+  Rationale for `alias or identifier or name`: model nodes often leave
+  `identifier` null when `alias` is set, so alias must be tried first.
+  `name` is a final fallback for edge cases. Sources have no `.alias`
+  and populate `.identifier`.
+
+  Returns the raw description string (may be empty). Caller decides
+  whether to emit a COMMENT clause.
+-#}
+{% macro _sv_find_column_description(tuple3, column_name) -%}
+  {%- set target_db = tuple3[0] -%}
+  {%- set target_schema = tuple3[1] -%}
+  {%- set target_identifier = tuple3[2] -%}
+  {%- set found = namespace(node=none) -%}
+
+  {%- for node in graph.nodes.values() -%}
+    {%- if found.node is none -%}
+      {%- set physical = node.alias or node.identifier or node.name -%}
+      {%- if physical
+          and (node.database or '') | lower == target_db
+          and (node.schema or '') | lower == target_schema
+          and (physical | lower) == target_identifier -%}
+        {%- set found.node = node -%}
+      {%- endif -%}
+    {%- endif -%}
+  {%- endfor -%}
+
+  {%- if found.node is none -%}
+    {%- for src in graph.sources.values() -%}
+      {%- if found.node is none -%}
+        {%- set physical = src.identifier or src.name -%}
+        {%- if physical
+            and (src.database or '') | lower == target_db
+            and (src.schema or '') | lower == target_schema
+            and (physical | lower) == target_identifier -%}
+          {%- set found.node = src -%}
+        {%- endif -%}
+      {%- endif -%}
+    {%- endfor -%}
+  {%- endif -%}
+
+  {%- if found.node is not none -%}
+    {%- set columns = found.node.columns or {} -%}
+    {%- set col_def = columns.get(column_name) -%}
+    {%- if col_def is none -%}
+      {# Case-insensitive fallback: yaml column keys may differ in case. #}
+      {%- set lookup_key = column_name | lower -%}
+      {%- for col_key, col_val in columns.items() -%}
+        {%- if col_def is none and (col_key | lower) == lookup_key -%}
+          {%- set col_def = col_val -%}
+        {%- endif -%}
+      {%- endfor -%}
+    {%- endif -%}
+    {%- if col_def is not none and col_def.description is not none -%}
+      {{- col_def.description -}}
+    {%- endif -%}
+  {%- endif -%}
+{%- endmacro %}

--- a/macros/relations/semantic_view/persist_column_comments.sql
+++ b/macros/relations/semantic_view/persist_column_comments.sql
@@ -102,147 +102,75 @@
   word-boundary checks on both sides. After the keyword match, skips
   whitespace and expects an opening `(`, then walks to the matching `)`.
 
+  Uses direct string iteration (for ch in sql) instead of range(n) to
+  avoid Jinja's MAX_RANGE sandbox limit on large compiled SQL bodies.
+  String literal boundaries are found via regex rather than nested loops.
+
   Returns a dict: {found, open_idx, close_idx}
     - found: bool
     - open_idx: index of the `(` after keyword (or -1)
     - close_idx: index of the matching `)` (or -1)
 -#}
 {% macro _sv_find_clause(sql, keyword) -%}
-  {%- set n = sql | length -%}
   {%- set kw_lower = keyword | lower -%}
   {%- set kw_len = keyword | length -%}
   {%- set lower_sql = sql | lower -%}
-  {%- set ns = namespace(i=0, depth=0, found=false, open_idx=-1, close_idx=-1) -%}
+  {%- set ns = namespace(depth=0, found=false, open_idx=-1, close_idx=-1, skip_until=0) -%}
 
-  {%- for _ in range(n) -%}
-    {%- if ns.i < n and not ns.found -%}
-      {%- set ch = sql[ns.i] -%}
+  {%- for ch in sql -%}
+    {%- set i = loop.index0 -%}
+    {%- if i >= ns.skip_until and not ns.found -%}
 
-      {#- Single-quoted string: skip contents, '' is an escaped quote -#}
       {%- if ch == "'" -%}
-        {%- set ns.i = ns.i + 1 -%}
-        {%- set inner = namespace(done=false) -%}
-        {%- for _ in range(n - ns.i) -%}
-          {%- if not inner.done and ns.i < n -%}
-            {%- if sql[ns.i] == "'" -%}
-              {%- if sql[ns.i + 1:ns.i + 2] == "'" -%}
-                {%- set ns.i = ns.i + 2 -%}
-              {%- else -%}
-                {%- set ns.i = ns.i + 1 -%}
-                {%- set inner.done = true -%}
-              {%- endif -%}
-            {%- else -%}
-              {%- set ns.i = ns.i + 1 -%}
-            {%- endif -%}
-          {%- endif -%}
-        {%- endfor -%}
+        {%- set end_q = modules.re.search("(?:[^']|'')*'", sql[i + 1:]) -%}
+        {%- set ns.skip_until = (i + 1 + end_q.end()) if end_q else (sql | length) -%}
 
-      {#- Dollar-quoted string: skip contents -#}
-      {%- elif ch == '$' and sql[ns.i + 1:ns.i + 2] == '$' -%}
-        {%- set ns.i = ns.i + 2 -%}
-        {%- set inner = namespace(done=false) -%}
-        {%- for _ in range(n - ns.i) -%}
-          {%- if not inner.done and ns.i < n -%}
-            {%- if sql[ns.i] == '$' and sql[ns.i + 1:ns.i + 2] == '$' -%}
-              {%- set ns.i = ns.i + 2 -%}
-              {%- set inner.done = true -%}
-            {%- else -%}
-              {%- set ns.i = ns.i + 1 -%}
-            {%- endif -%}
-          {%- endif -%}
-        {%- endfor -%}
+      {%- elif ch == '$' and sql[i + 1:i + 2] == '$' -%}
+        {%- set end_dq = sql.find('$$', i + 2) -%}
+        {%- set ns.skip_until = (end_dq + 2) if end_dq != -1 else (sql | length) -%}
 
       {%- elif ch == '(' -%}
         {%- set ns.depth = ns.depth + 1 -%}
-        {%- set ns.i = ns.i + 1 -%}
 
       {%- elif ch == ')' -%}
         {%- set ns.depth = ns.depth - 1 -%}
-        {%- set ns.i = ns.i + 1 -%}
 
-      {#- At depth 0, check for keyword with word-boundary guards -#}
-      {%- elif ns.depth == 0 and lower_sql[ns.i:ns.i + kw_len] == kw_lower -%}
-        {%- set prev_char = sql[ns.i - 1:ns.i] -%}
+      {%- elif ns.depth == 0 and lower_sql[i:i + kw_len] == kw_lower -%}
+        {%- set prev_char = sql[i - 1:i] -%}
         {%- set prev_ok = prev_char == '' or not (prev_char.isalnum() or prev_char == '_') -%}
-        {%- set after_pos = ns.i + kw_len -%}
+        {%- set after_pos = i + kw_len -%}
         {%- set next_char = sql[after_pos:after_pos + 1] -%}
         {%- set next_ok = next_char == '' or not (next_char.isalnum() or next_char == '_') -%}
         {%- if prev_ok and next_ok -%}
-          {%- set ns.i = after_pos -%}
-          {#- Skip whitespace to find the ( -#}
-          {%- set ws = namespace(done=false) -%}
-          {%- for _ in range(n - ns.i) -%}
-            {%- if not ws.done and ns.i < n -%}
-              {%- if sql[ns.i] in [' ', '\t', '\n', '\r'] -%}
-                {%- set ns.i = ns.i + 1 -%}
-              {%- else -%}
-                {%- set ws.done = true -%}
-              {%- endif -%}
-            {%- endif -%}
-          {%- endfor -%}
-          {%- if ns.i < n and sql[ns.i] == '(' -%}
-            {%- set ns.open_idx = ns.i -%}
-            {%- set ns.i = ns.i + 1 -%}
-            {#- Walk to the matching ) tracking depth from 1 -#}
-            {%- set depth_inner = namespace(d=1, done=false) -%}
-            {%- for _ in range(n - ns.i) -%}
-              {%- if not depth_inner.done and ns.i < n -%}
-                {%- set ic = sql[ns.i] -%}
+          {%- set ws_match = modules.re.match('[\\s]*\\(', sql[after_pos:]) -%}
+          {%- if ws_match -%}
+            {%- set open_idx = after_pos + (ws_match.group(0) | length) - 1 -%}
+            {%- set ns.open_idx = open_idx -%}
+            {%- set inner = namespace(depth=1, skip_until=0) -%}
+            {%- for ic in sql[open_idx + 1:] -%}
+              {%- set j = open_idx + 1 + loop.index0 -%}
+              {%- if j >= inner.skip_until and inner.depth > 0 -%}
                 {%- if ic == "'" -%}
-                  {%- set ns.i = ns.i + 1 -%}
-                  {%- set qi = namespace(done=false) -%}
-                  {%- for _ in range(n - ns.i) -%}
-                    {%- if not qi.done and ns.i < n -%}
-                      {%- if sql[ns.i] == "'" -%}
-                        {%- if sql[ns.i + 1:ns.i + 2] == "'" -%}
-                          {%- set ns.i = ns.i + 2 -%}
-                        {%- else -%}
-                          {%- set ns.i = ns.i + 1 -%}
-                          {%- set qi.done = true -%}
-                        {%- endif -%}
-                      {%- else -%}
-                        {%- set ns.i = ns.i + 1 -%}
-                      {%- endif -%}
-                    {%- endif -%}
-                  {%- endfor -%}
-                {%- elif ic == '$' and sql[ns.i + 1:ns.i + 2] == '$' -%}
-                  {%- set ns.i = ns.i + 2 -%}
-                  {%- set qi = namespace(done=false) -%}
-                  {%- for _ in range(n - ns.i) -%}
-                    {%- if not qi.done and ns.i < n -%}
-                      {%- if sql[ns.i] == '$' and sql[ns.i + 1:ns.i + 2] == '$' -%}
-                        {%- set ns.i = ns.i + 2 -%}
-                        {%- set qi.done = true -%}
-                      {%- else -%}
-                        {%- set ns.i = ns.i + 1 -%}
-                      {%- endif -%}
-                    {%- endif -%}
-                  {%- endfor -%}
+                  {%- set end_q = modules.re.search("(?:[^']|'')*'", sql[j + 1:]) -%}
+                  {%- set inner.skip_until = (j + 1 + end_q.end()) if end_q else (sql | length) -%}
+                {%- elif ic == '$' and sql[j + 1:j + 2] == '$' -%}
+                  {%- set end_dq = sql.find('$$', j + 2) -%}
+                  {%- set inner.skip_until = (end_dq + 2) if end_dq != -1 else (sql | length) -%}
                 {%- elif ic == '(' -%}
-                  {%- set depth_inner.d = depth_inner.d + 1 -%}
-                  {%- set ns.i = ns.i + 1 -%}
+                  {%- set inner.depth = inner.depth + 1 -%}
                 {%- elif ic == ')' -%}
-                  {%- set depth_inner.d = depth_inner.d - 1 -%}
-                  {%- if depth_inner.d == 0 -%}
-                    {%- set ns.close_idx = ns.i -%}
+                  {%- set inner.depth = inner.depth - 1 -%}
+                  {%- if inner.depth == 0 -%}
+                    {%- set ns.close_idx = j -%}
                     {%- set ns.found = true -%}
-                    {%- set depth_inner.done = true -%}
                   {%- endif -%}
-                  {%- set ns.i = ns.i + 1 -%}
-                {%- else -%}
-                  {%- set ns.i = ns.i + 1 -%}
                 {%- endif -%}
               {%- endif -%}
             {%- endfor -%}
-          {%- else -%}
-            {%- set ns.i = ns.i + 1 -%}
+            {%- set ns.skip_until = sql | length -%}
           {%- endif -%}
-        {%- else -%}
-          {%- set ns.i = ns.i + 1 -%}
         {%- endif -%}
 
-      {%- else -%}
-        {%- set ns.i = ns.i + 1 -%}
       {%- endif -%}
     {%- endif -%}
   {%- endfor -%}
@@ -256,79 +184,37 @@
 
   Splits `body` on commas at paren depth 0, outside '...' and $$...$$
   regions. Returns a list of entry strings.
+
+  Uses direct string iteration (for ch in body) instead of range(n) to
+  avoid Jinja's MAX_RANGE sandbox limit on large clause bodies.
+  Tracks entry start position and slices body[start:i] at each depth-0 comma.
 -#}
 {% macro _sv_split_depth0(body) -%}
-  {%- set n = body | length -%}
-  {%- set ns = namespace(i=0, depth=0, current='') -%}
+  {%- set ns = namespace(depth=0, start=0, skip_until=0) -%}
   {%- set entries = [] -%}
 
-  {%- for _ in range(n) -%}
-    {%- if ns.i < n -%}
-      {%- set ch = body[ns.i] -%}
-
+  {%- for ch in body -%}
+    {%- set i = loop.index0 -%}
+    {%- if i >= ns.skip_until -%}
       {%- if ch == "'" -%}
-        {%- set ns.current = ns.current ~ ch -%}
-        {%- set ns.i = ns.i + 1 -%}
-        {%- set inner = namespace(done=false) -%}
-        {%- for _ in range(n - ns.i) -%}
-          {%- if not inner.done and ns.i < n -%}
-            {%- if body[ns.i] == "'" -%}
-              {%- if body[ns.i + 1:ns.i + 2] == "'" -%}
-                {%- set ns.current = ns.current ~ "''" -%}
-                {%- set ns.i = ns.i + 2 -%}
-              {%- else -%}
-                {%- set ns.current = ns.current ~ "'" -%}
-                {%- set ns.i = ns.i + 1 -%}
-                {%- set inner.done = true -%}
-              {%- endif -%}
-            {%- else -%}
-              {%- set ns.current = ns.current ~ body[ns.i] -%}
-              {%- set ns.i = ns.i + 1 -%}
-            {%- endif -%}
-          {%- endif -%}
-        {%- endfor -%}
-
-      {%- elif ch == '$' and body[ns.i + 1:ns.i + 2] == '$' -%}
-        {%- set ns.current = ns.current ~ '$$' -%}
-        {%- set ns.i = ns.i + 2 -%}
-        {%- set inner = namespace(done=false) -%}
-        {%- for _ in range(n - ns.i) -%}
-          {%- if not inner.done and ns.i < n -%}
-            {%- if body[ns.i] == '$' and body[ns.i + 1:ns.i + 2] == '$' -%}
-              {%- set ns.current = ns.current ~ '$$' -%}
-              {%- set ns.i = ns.i + 2 -%}
-              {%- set inner.done = true -%}
-            {%- else -%}
-              {%- set ns.current = ns.current ~ body[ns.i] -%}
-              {%- set ns.i = ns.i + 1 -%}
-            {%- endif -%}
-          {%- endif -%}
-        {%- endfor -%}
-
+        {%- set end_q = modules.re.search("(?:[^']|'')*'", body[i + 1:]) -%}
+        {%- set ns.skip_until = (i + 1 + end_q.end()) if end_q else (body | length) -%}
+      {%- elif ch == '$' and body[i + 1:i + 2] == '$' -%}
+        {%- set end_dq = body.find('$$', i + 2) -%}
+        {%- set ns.skip_until = (end_dq + 2) if end_dq != -1 else (body | length) -%}
       {%- elif ch == '(' -%}
         {%- set ns.depth = ns.depth + 1 -%}
-        {%- set ns.current = ns.current ~ ch -%}
-        {%- set ns.i = ns.i + 1 -%}
-
       {%- elif ch == ')' -%}
         {%- set ns.depth = ns.depth - 1 -%}
-        {%- set ns.current = ns.current ~ ch -%}
-        {%- set ns.i = ns.i + 1 -%}
-
       {%- elif ch == ',' and ns.depth == 0 -%}
-        {%- do entries.append(ns.current) -%}
-        {%- set ns.current = '' -%}
-        {%- set ns.i = ns.i + 1 -%}
-
-      {%- else -%}
-        {%- set ns.current = ns.current ~ ch -%}
-        {%- set ns.i = ns.i + 1 -%}
+        {%- do entries.append(body[ns.start:i]) -%}
+        {%- set ns.start = i + 1 -%}
       {%- endif -%}
     {%- endif -%}
   {%- endfor -%}
 
-  {%- if ns.current | trim | length > 0 -%}
-    {%- do entries.append(ns.current) -%}
+  {%- if body[ns.start:] | trim | length > 0 -%}
+    {%- do entries.append(body[ns.start:]) -%}
   {%- endif -%}
 
   {%- do return(entries) -%}

--- a/macros/utils/semantic_view_ref.sql
+++ b/macros/utils/semantic_view_ref.sql
@@ -1,4 +1,4 @@
--- Copyright 2025 Snowflake Inc. 
+-- Copyright 2025 Snowflake Inc.
 -- SPDX-License-Identifier: Apache-2.0
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,16 +13,12 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-{{ config(materialized='test') }}
+{% macro sv_ref(model_name) %}
+  {%- set rel = ref(model_name) -%}
+  {{ rel.database }}.{{ rel.schema }}.{{ rel.identifier }}
+{%- endmacro %}
 
--- Compare result of a table that refers to the raw semantic view to calling it directly
-with table_ref as (
-  select * from {{ ref('table_refer_to_raw_semantic_view') }}
-), sv as (
-  select * from semantic_view({{ dbt_semantic_view.sv_source('seed_sources', 'raw_semantic_view') }} metrics total_rows)
-)
-select 'table refer raw result does not match semantic view result' as error_message
-from table_ref, sv
-where table_ref.total_rows != sv.total_rows
-
-
+{% macro sv_source(source_name, table_name) %}
+  {%- set rel = source(source_name, table_name) -%}
+  {{ rel.database }}.{{ rel.schema }}.{{ rel.identifier }}
+{%- endmacro %}


### PR DESCRIPTION
## Problem

`dbt build --empty` (used in CI/CD for schema validation) fails for semantic view models. The `--empty` flag rewrites `ref()`/`source()` into subqueries like `(select * from TABLE where false limit 0)`, which breaks three contexts that require bare table identifiers:

1. **`CREATE SEMANTIC VIEW` DDL** — `TABLES()` clause
2. **`semantic_view()` query function** — table argument
3. **`get_ddl()` calls in tests** — string argument

### Root cause

The `--empty` rewriting is hardcoded in Python (`BaseRelation.render_limited()` in dbt-core). There is no dispatchable macro to override it at the package level.

## Solution

Two new utility macros: `sv_ref()` and `sv_source()`.

They call dbt's native `ref()`/`source()` internally (preserving DAG lineage and execution ordering) but render the relation as `DATABASE.SCHEMA.IDENTIFIER` using the Relation object's component properties — which are stable public API and unaffected by `--empty`.

### Usage

```sql
-- Semantic view definition (TABLES clause):
TABLES(t1 AS {{ dbt_semantic_view.sv_ref('my_table') }})

-- Querying a semantic view:
select * from semantic_view({{ dbt_semantic_view.sv_ref('my_view') }} metrics total_rows)

-- For sources:
TABLES(t2 AS {{ dbt_semantic_view.sv_source('my_source', 'my_table') }})
```

Standard `ref()`/`source()` should still be used in normal SELECT contexts where subquery wrapping is harmless.

### Alternatives considered

**Regex cleanup in materialization** — Strip the `--empty` subquery pattern from compiled SQL before executing DDL. Rejected: tied to dbt's internal subquery format (an implementation detail), and silent regex mismatch is harder to debug than a clear error.

**graph.nodes lookup ([proposed in #11](https://github.com/Snowflake-Labs/dbt_semantic_view/issues/11))** — Manually resolve relation names from the dbt graph without calling `ref()`. Rejected: breaks DAG dependency tracking (dbt won't know about the relationship), and has correctness issues with custom schemas, cross-project refs, and aliases.

**Tag-based exclusion** — Exclude semantic view models from `--empty` runs. Rejected: fragile CI/CD configuration, provides zero validation value, and silently breaks when new models are added without the tag.

## Verification

Both pass with 19/19:
```
dbt build --target snowflake --empty   # PASS=19 ERROR=0
dbt build --target snowflake           # PASS=19 ERROR=0
```

Closes #11