### PR TITLE
Add semantic view materialization and CoA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ All config options are set via `{{ config(...) }}` at the top of your model file
 |---|---|---|---|
 | `copy_grants` | bool | `false` | Preserve grants when the view is replaced |
 | `create_or_alter` | bool | `false` | Use `CREATE OR ALTER` instead of `CREATE OR REPLACE` — non-destructive, preserves materializations and grants across runs |
+| `max_staleness` | string | none | Inject a `MAX_STALENESS = '<value>'` clause — required when `sv_materializations` is set; mutually exclusive with a `MAX_STALENESS` clause in the model SQL body |
 | `sv_materializations` | string (YAML) | none | Declarative materialization spec; see below |
 
 `copy_grants` only applies to `CREATE OR REPLACE`. Snowflake does not support `COPY GRANTS` with `CREATE OR ALTER`.
@@ -119,53 +120,41 @@ METRICS(fact.revenue AS SUM(fact.revenue_amount))
 
 Declares one or more materializations on the semantic view. On every `dbt run` the package calls `SYSTEM$MANAGE_SEMANTIC_VIEW_MATERIALIZATIONS_FROM_YAML`, which diffs the desired state against the current state and only adds, updates, or drops what changed.
 
-The value is a YAML string matching the format accepted by the stored procedure:
+We highly recommend setting `create_or_alter=true` whenever you use `sv_materializations`. Without it, the model uses `CREATE OR REPLACE`, which drops and recreates the semantic view — and every materialization on it — on each run.
+
+`MAX_STALENESS` is required when using `sv_materializations`. You can set it via the `max_staleness` config key (recommended) or by including the clause directly in the model SQL body.
+
+The simplest example:
 
 ```sql
 {{ config(
     materialized='semantic_view',
     create_or_alter=true,
+    max_staleness='1 hour',
     sv_materializations="""
 materializations:
-  - name: by_region_date
+  - name: by_region
     warehouse: MY_WAREHOUSE
     dimensions:
       - table: fact
         name: region
-      - table: fact
-        name: date
     metrics:
       - table: fact
         name: revenue
-    filter_clause: "WHERE (fact.date >= '2020-01-01')"  # optional: mutable filter — planner rewrites
-                                                         #   queries whose filter matches or is stricter
-    immutable_where: "date < '2024-01-01'"               # optional: freeze historical rows permanently
-                                                         #   out of refresh; predicate columns must be
-                                                         #   included in this materialization's dimensions
-    refresh_mode: AUTO                       # optional: AUTO (default) | INCREMENTAL | FULL
 """
 ) }}
 
 TABLES(fact AS {{ ref('fact_sales') }})
-DIMENSIONS(fact.region as region, fact.date as date)
+DIMENSIONS(fact.region as region)
 METRICS(fact.revenue AS SUM(fact.revenue_amount))
-MAX_STALENESS = '1 hour'
 ```
 
-Use `filter_clause` for a mutable materialization filter. The value is passed through to Snowflake's
-`ADD MATERIALIZATION` statement, so include the `WHERE (...)` keyword and predicate text. Do not use a
-top-level YAML key named `where`.
-
-Use `immutable_where` for a frozen historical region. It is mutually exclusive with `filter_clause` for a
-single materialization. The predicate should reference the materialization output column name, not a
-qualified source expression, and that column must be part of the materialization's dimensions.
-
-When you need Jinja expressions inside the YAML (e.g. to inject a warehouse from the dbt profile or an environment variable), use a `{% set %}` block to build the string first:
+When you need Jinja expressions inside the YAML (e.g. to inject the warehouse from the dbt profile or an environment variable), use a `{% set %}` block to build the string first:
 
 ```sql
 {%- set sv_mats_yaml -%}
 materializations:
-  - name: by_region_date
+  - name: by_region
     warehouse: {{ target.warehouse }}
     dimensions:
       - table: fact
@@ -178,6 +167,7 @@ materializations:
 {{ config(
     materialized='semantic_view',
     create_or_alter=true,
+    max_staleness='1 hour',
     sv_materializations=sv_mats_yaml
 ) }}
 
@@ -186,11 +176,44 @@ DIMENSIONS(fact.region as region)
 METRICS(fact.revenue AS SUM(fact.revenue_amount))
 ```
 
+**Optional: `filter_clause`** — restrict which rows the materialization pre-computes. The query planner uses the materialization when a query's filter matches or is stricter. Include the `WHERE (...)` keyword:
+
+```yaml
+    filter_clause: "WHERE (fact.date >= '2020-01-01')"
+```
+
+Do not use a top-level YAML key named `where` — it is not supported.
+
+**Optional: `immutable_where`** — permanently exclude rows from refresh (e.g. rows that will never change). Mutually exclusive with `filter_clause` for a single materialization. The predicate must reference the materialization output column name (not a qualified source expression), and that column must be included in the materialization's dimensions:
+
+```yaml
+    immutable_where: "date < '2024-01-01'"
+```
+
+**Optional: `refresh_mode`** — `AUTO` (default) | `INCREMENTAL` | `FULL`. Note: this field is silently ignored by `SYSTEM$MANAGE_SEMANTIC_VIEW_MATERIALIZATIONS_FROM_YAML` — `REFRESH_MODE` is a DDL-only parameter and is not part of the SP's YAML schema. Snowflake defaults to `AUTO` (incremental where possible). To set a specific refresh mode, use `ALTER SEMANTIC VIEW ... ADD MATERIALIZATION ... REFRESH_MODE = FULL AS DIMENSIONS ... METRICS ...` directly.
+
 To set `LOG_EVENT_LEVEL` on materializations (e.g. for event table alerting), use a `post_hook`:
 
 ```sql
 post_hook=["ALTER SEMANTIC VIEW {{ this }} ALTER MATERIALIZATION my_mat SET LOG_EVENT_LEVEL = 'INFO'"]
 ```
+
+#### Built-in materialization tests
+
+The package ships two generic dbt tests you can attach to any semantic view model to verify that materializations are in place and healthy:
+
+```yaml
+models:
+  - name: my_semantic_view
+    tests:
+      - dbt_semantic_view.materialization_exists:
+          materialization_name: my_mat
+      - dbt_semantic_view.materialization_is_active:
+          materialization_name: my_mat
+```
+
+- **`materialization_exists`** — fails if the named materialization is absent from the semantic view.
+- **`materialization_is_active`** — fails if the materialization is absent or suspended.
 
 ### Note on documentation persistence (persist_docs)
 At this time, dbt-driven documentation persistence for Semantic Views (`persist_docs`) is not supported by this package. Enabling `persist_docs` and adding model or column descriptions will not affect Semantic Views.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Professional dbt macros and integration tests for building, dropping, and renami
 - **Materialization**: `semantic_view`
 - **Warehouse**: Snowflake
 - **dbt Compatibility**: dbt 1.x
+- **Supports**: `CREATE OR ALTER`, `MAX_STALENESS`, and declarative materialization management
 
 ### Quickstart
 Follow these steps on macOS/Linux with Python 3 installed. No prior dbt installation is required.
@@ -88,6 +89,107 @@ from semantic_view(
   [ DIMENSIONS <dimension_expr> ]
   [ WHERE <predicate> ]
 )
+```
+
+### Config options
+
+All config options are set via `{{ config(...) }}` at the top of your model file.
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `copy_grants` | bool | `false` | Preserve grants when the view is replaced |
+| `create_or_alter` | bool | `false` | Use `CREATE OR ALTER` instead of `CREATE OR REPLACE` — non-destructive, preserves materializations and grants across runs |
+| `sv_materializations` | string (YAML) | none | Declarative materialization spec; see below |
+
+`copy_grants` only applies to `CREATE OR REPLACE`. Snowflake does not support `COPY GRANTS` with `CREATE OR ALTER`.
+
+#### `create_or_alter`
+
+Use `CREATE OR ALTER` when your semantic view has materializations. `CREATE OR REPLACE` drops and recreates the view on every run, which silently removes all attached materializations.
+
+```sql
+{{ config(materialized='semantic_view', create_or_alter=true) }}
+
+TABLES(fact AS {{ ref('fact_sales') }})
+DIMENSIONS(fact.region as region)
+METRICS(fact.revenue AS SUM(fact.revenue_amount))
+```
+
+#### `sv_materializations`
+
+Declares one or more materializations on the semantic view. On every `dbt run` the package calls `SYSTEM$MANAGE_SEMANTIC_VIEW_MATERIALIZATIONS_FROM_YAML`, which diffs the desired state against the current state and only adds, updates, or drops what changed.
+
+The value is a YAML string matching the format accepted by the stored procedure:
+
+```sql
+{{ config(
+    materialized='semantic_view',
+    create_or_alter=true,
+    sv_materializations="""
+materializations:
+  - name: by_region_date
+    warehouse: MY_WAREHOUSE
+    dimensions:
+      - table: fact
+        name: region
+      - table: fact
+        name: date
+    metrics:
+      - table: fact
+        name: revenue
+    filter_clause: "WHERE (fact.date >= '2020-01-01')"  # optional: mutable filter — planner rewrites
+                                                         #   queries whose filter matches or is stricter
+    immutable_where: "date < '2024-01-01'"               # optional: freeze historical rows permanently
+                                                         #   out of refresh; predicate columns must be
+                                                         #   included in this materialization's dimensions
+    refresh_mode: AUTO                       # optional: AUTO (default) | INCREMENTAL | FULL
+"""
+) }}
+
+TABLES(fact AS {{ ref('fact_sales') }})
+DIMENSIONS(fact.region as region, fact.date as date)
+METRICS(fact.revenue AS SUM(fact.revenue_amount))
+MAX_STALENESS = '1 hour'
+```
+
+Use `filter_clause` for a mutable materialization filter. The value is passed through to Snowflake's
+`ADD MATERIALIZATION` statement, so include the `WHERE (...)` keyword and predicate text. Do not use a
+top-level YAML key named `where`.
+
+Use `immutable_where` for a frozen historical region. It is mutually exclusive with `filter_clause` for a
+single materialization. The predicate should reference the materialization output column name, not a
+qualified source expression, and that column must be part of the materialization's dimensions.
+
+When you need Jinja expressions inside the YAML (e.g. to inject a warehouse from the dbt profile or an environment variable), use a `{% set %}` block to build the string first:
+
+```sql
+{%- set sv_mats_yaml -%}
+materializations:
+  - name: by_region_date
+    warehouse: {{ target.warehouse }}
+    dimensions:
+      - table: fact
+        name: region
+    metrics:
+      - table: fact
+        name: revenue
+{%- endset -%}
+
+{{ config(
+    materialized='semantic_view',
+    create_or_alter=true,
+    sv_materializations=sv_mats_yaml
+) }}
+
+TABLES(fact AS {{ ref('fact_sales') }})
+DIMENSIONS(fact.region as region)
+METRICS(fact.revenue AS SUM(fact.revenue_amount))
+```
+
+To set `LOG_EVENT_LEVEL` on materializations (e.g. for event table alerting), use a `post_hook`:
+
+```sql
+post_hook=["ALTER SEMANTIC VIEW {{ this }} ALTER MATERIALIZATION my_mat SET LOG_EVENT_LEVEL = 'INFO'"]
 ```
 
 ### Note on documentation persistence (persist_docs)

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -27,3 +27,9 @@ models:
   - name: semantic_view_with_calc_name_copy_grants
     config:
       copy_grants: true
+  - name: semantic_view_with_materializations
+    tests:
+      - dbt_semantic_view.materialization_exists:
+          materialization_name: test_mat_by_value
+      - dbt_semantic_view.materialization_is_active:
+          materialization_name: test_mat_by_value

--- a/integration_tests/models/semantic_view_with_materializations.sql
+++ b/integration_tests/models/semantic_view_with_materializations.sql
@@ -1,0 +1,63 @@
+-- Copyright 2025 Snowflake Inc. 
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+{#
+  Use a set block to build the YAML when you need Jinja expressions inside it
+  (e.g. injecting the warehouse from the dbt profile or an env_var).
+  For static YAML with no Jinja, you can pass the string directly in config().
+#}
+{%- set sv_mats_yaml -%}
+materializations:
+  - name: test_mat_by_value
+    warehouse: {{ target.warehouse }}
+    dimensions:
+      - table: t1
+        name: value
+    metrics:
+      - table: t1
+        name: total_rows
+  - name: test_mat_filtered_by_value
+    warehouse: {{ target.warehouse }}
+    dimensions:
+      - table: t1
+        name: value
+    metrics:
+      - table: t1
+        name: total_rows
+    filter_clause: "WHERE (t1.count >= 1)"
+  - name: test_mat_immutable_by_value
+    warehouse: {{ target.warehouse }}
+    dimensions:
+      - table: t1
+        name: value
+    metrics:
+      - table: t1
+        name: total_rows
+    immutable_where: "value < 10"
+{%- endset -%}
+
+{{
+    config(
+        materialized='semantic_view',
+        create_or_alter=true,
+        sv_materializations=sv_mats_yaml
+    )
+}}
+
+TABLES(t1 AS {{ ref('base_table') }})
+DIMENSIONS(t1.count as value)
+METRICS(t1.total_rows AS SUM(t1.count))
+MAX_STALENESS = '1 hour'
+COMMENT='semantic view with materialization for integration test'

--- a/integration_tests/tests/semantic_view_with_materializations_has_mat.sql
+++ b/integration_tests/tests/semantic_view_with_materializations_has_mat.sql
@@ -1,0 +1,50 @@
+-- Copyright 2025 Snowflake Inc. 
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Verifies that the materialization declared in sv_materializations was actually
+-- created on the semantic view. Returns a row (test failure) if it is missing.
+
+{% call statement('show_mats', fetch_result=True) %}
+  show materializations in semantic view {{ ref('semantic_view_with_materializations') }}
+{% endcall %}
+
+{%- set result = load_result('show_mats') -%}
+{%- set base_found = [] -%}
+{%- set filtered_found = [] -%}
+{%- set immutable_found = [] -%}
+{%- for row in result['data'] -%}
+  {%- if row[0] | upper == 'TEST_MAT_BY_VALUE' -%}
+    {%- do base_found.append(1) -%}
+  {%- endif -%}
+  {%- if row[0] | upper == 'TEST_MAT_FILTERED_BY_VALUE' -%}
+    {%- do filtered_found.append(1) -%}
+  {%- endif -%}
+  {%- if row[0] | upper == 'TEST_MAT_IMMUTABLE_BY_VALUE' and 'value < 10' in (row[7] | lower) -%}
+    {%- do immutable_found.append(1) -%}
+  {%- endif -%}
+{%- endfor -%}
+
+select 'materialization test_mat_by_value was not created on semantic_view_with_materializations' as error_message
+where {{ base_found | length }} = 0
+
+union all
+
+select 'materialization test_mat_filtered_by_value was not created on semantic_view_with_materializations' as error_message
+where {{ filtered_found | length }} = 0
+
+union all
+
+select 'materialization test_mat_immutable_by_value was not created with immutable_where on semantic_view_with_materializations' as error_message
+where {{ immutable_found | length }} = 0

--- a/macros/relations/semantic_view/create.sql
+++ b/macros/relations/semantic_view/create.sql
@@ -32,6 +32,25 @@
 {%- endmacro %}
 
 
+{% macro snowflake__get_create_or_alter_semantic_view_sql(relation, sql) -%}
+{#-
+--  Produce DDL that creates or alters a semantic view (non-destructive).
+--  Unlike CREATE OR REPLACE, CREATE OR ALTER preserves existing materializations
+--  and grants when only the SV body changes.
+--
+--  Args:
+--  - relation: Union[SnowflakeRelation, str]
+--  - sql: str - the code defining the model
+--  Returns:
+--      A valid DDL statement using CREATE OR ALTER semantics.
+-#}
+
+  create or alter semantic view {{ relation }}
+  {{ sql }}
+
+{%- endmacro %}
+
+
 {% macro append_copy_grants_if_missing(sql) -%}
   {%- set s = (sql | trim) -%}
   {%- set had_semicolon = (s[-1:] == ';') -%}
@@ -58,13 +77,15 @@
 {% macro snowflake__create_or_replace_semantic_view() %}
   {%- set identifier = model['alias'] -%}
 
-  {%- set copy_grants = config.get('copy_grants', default=false) -%}
+  {%- set copy_grants         = config.get('copy_grants',         default=false) -%}
+  {%- set create_or_alter     = config.get('create_or_alter',     default=false) -%}
+  {%- set sv_materializations = config.get('sv_materializations', default=none)  -%}
 
   {%- set target_relation = api.Relation.create(
       identifier=identifier, schema=schema, database=database,
       type='view') -%}
 
-  {%- if copy_grants -%}
+  {%- if copy_grants and not create_or_alter -%}
     {%- set sql = dbt_semantic_view.append_copy_grants_if_missing(sql) -%}
   {%- endif -%}
 
@@ -72,8 +93,17 @@
 
   -- build model
   {% call statement('main') -%}
-    {{ dbt_semantic_view.snowflake__get_create_semantic_view_sql(target_relation, sql) }}
+    {%- if create_or_alter -%}
+      {{ dbt_semantic_view.snowflake__get_create_or_alter_semantic_view_sql(target_relation, sql) }}
+    {%- else -%}
+      {{ dbt_semantic_view.snowflake__get_create_semantic_view_sql(target_relation, sql) }}
+    {%- endif -%}
   {%- endcall %}
+
+  {%- if sv_materializations is not none -%}
+    {%- set sv_fqn = target_relation.render() | replace("'", "''") -%}
+    {{ dbt_semantic_view.snowflake__sync_sv_materializations(sv_fqn, sv_materializations) }}
+  {%- endif -%}
 
   {{ run_hooks(post_hooks) }}
 

--- a/macros/relations/semantic_view/create.sql
+++ b/macros/relations/semantic_view/create.sql
@@ -80,6 +80,27 @@
   {%- set copy_grants         = config.get('copy_grants',         default=false) -%}
   {%- set create_or_alter     = config.get('create_or_alter',     default=false) -%}
   {%- set sv_materializations = config.get('sv_materializations', default=none)  -%}
+  {%- set max_staleness       = config.get('max_staleness',       default=none)  -%}
+
+  {# sv_materializations requires MAX_STALENESS #}
+  {%- if sv_materializations is not none -%}
+    {%- if max_staleness is none and 'max_staleness' not in (sql | lower) -%}
+      {{ exceptions.raise_compiler_error(
+          "sv_materializations requires MAX_STALENESS. Set max_staleness in config() "
+          ~ "or include MAX_STALENESS in the model SQL body."
+      ) }}
+    {%- endif -%}
+  {%- endif -%}
+
+  {# Inject max_staleness from config into the SQL body #}
+  {%- if max_staleness is not none -%}
+    {%- if 'max_staleness' in (sql | lower) -%}
+      {{ exceptions.raise_compiler_error(
+          "max_staleness is defined in both config() and the model SQL body. Remove one."
+      ) }}
+    {%- endif -%}
+    {%- set sql = sql ~ "\nMAX_STALENESS = '" ~ max_staleness ~ "'" -%}
+  {%- endif -%}
 
   {%- set target_relation = api.Relation.create(
       identifier=identifier, schema=schema, database=database,

--- a/macros/relations/semantic_view/materializations.sql
+++ b/macros/relations/semantic_view/materializations.sql
@@ -1,0 +1,57 @@
+-- Copyright 2025 Snowflake Inc. 
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+{#
+  snowflake__sync_sv_materializations
+
+  Declaratively synchronises the materializations on a semantic view by
+  calling SYSTEM$MANAGE_SEMANTIC_VIEW_MATERIALIZATIONS_FROM_YAML.  The
+  stored procedure performs the full diff (add / update / drop) so no
+  diff logic is needed here.
+
+  Args:
+    sv_fqn        - fully-qualified semantic view name, e.g.
+                    'MY_DB.MY_SCHEMA.MY_SEMANTIC_VIEW'
+    yaml_spec     - YAML string accepted by the SP (see format below)
+
+  YAML format:
+    materializations:
+      - name: my_mat
+        warehouse: MY_WAREHOUSE
+        dimensions:
+          - table: entity
+            name: dim_col
+        metrics:
+          - table: entity
+            name: metric_col
+        filter_clause: "WHERE (entity.date_col >= '2024-01-01')"  # optional: mutable filter;
+                                                                  #   planner rewrites queries whose
+                                                                  #   filter matches or is stricter
+        immutable_where: "date_col < '2024-01-01'"                # optional: freeze historical rows;
+                                                                  #   mutually exclusive with filter_clause
+                                                                  #   and date_col must be a materialized
+                                                                  #   dimension
+        refresh_mode: AUTO                            # optional: AUTO (default) | INCREMENTAL | FULL
+#}
+{% macro snowflake__sync_sv_materializations(sv_fqn, yaml_spec) %}
+  {% call statement('sync_sv_materializations', fetch_result=False) -%}
+    call system$manage_semantic_view_materializations_from_yaml(
+      '{{ sv_fqn }}',
+      $$
+{{ yaml_spec }}
+      $$
+    )
+  {%- endcall %}
+{% endmacro %}

--- a/macros/relations/semantic_view/materializations.sql
+++ b/macros/relations/semantic_view/materializations.sql
@@ -44,6 +44,8 @@
                                                                   #   and date_col must be a materialized
                                                                   #   dimension
         refresh_mode: AUTO                            # optional: AUTO (default) | INCREMENTAL | FULL
+                                                      # NOTE: silently ignored by the SP — refresh_mode
+                                                      # is a DDL-only parameter; Snowflake always uses AUTO
 #}
 {% macro snowflake__sync_sv_materializations(sv_fqn, yaml_spec) %}
   {% call statement('sync_sv_materializations', fetch_result=False) -%}

--- a/macros/tests/materialization_tests.sql
+++ b/macros/tests/materialization_tests.sql
@@ -1,0 +1,82 @@
+-- Copyright 2025 Snowflake Inc. 
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+{#
+  Generic dbt test: assert a named materialization exists on a semantic view.
+
+  Usage in schema.yml:
+    models:
+      - name: my_semantic_view
+        tests:
+          - dbt_semantic_view.materialization_exists:
+              materialization_name: my_mat
+#}
+{% test materialization_exists(model, materialization_name) %}
+  {%- call statement('show_mats', fetch_result=True) -%}
+    show materializations in semantic view {{ model }}
+  {%- endcall -%}
+  {%- set result = load_result('show_mats') -%}
+  {%- set found = [] -%}
+  {%- for row in result['data'] -%}
+    {%- if row[0] | upper == materialization_name | upper -%}
+      {%- do found.append(1) -%}
+    {%- endif -%}
+  {%- endfor -%}
+  select 'materialization {{ materialization_name }} does not exist on {{ model }}' as error_message
+  where {{ found | length }} = 0
+{% endtest %}
+
+
+{#
+  Generic dbt test: assert a named materialization exists and is not suspended.
+
+  Usage in schema.yml:
+    models:
+      - name: my_semantic_view
+        tests:
+          - dbt_semantic_view.materialization_is_active:
+              materialization_name: my_mat
+#}
+{% test materialization_is_active(model, materialization_name) %}
+  {%- call statement('show_mats_active', fetch_result=True) -%}
+    show materializations in semantic view {{ model }}
+  {%- endcall -%}
+  {%- set result = load_result('show_mats_active') -%}
+
+  {# SCHEDULING_STATUS is column 1 in SHOW MATERIALIZATIONS output #}
+  {%- set ns = namespace(status_idx=1) -%}
+  {%- for col in result['columns'] -%}
+    {%- if col.name | upper == 'SCHEDULING_STATUS' -%}
+      {%- set ns.status_idx = loop.index0 -%}
+    {%- endif -%}
+  {%- endfor -%}
+
+  {%- set found = [] -%}
+  {%- set active = [] -%}
+  {%- for row in result['data'] -%}
+    {%- if row[0] | upper == materialization_name | upper -%}
+      {%- do found.append(1) -%}
+      {%- if (row[ns.status_idx] | upper) != 'SUSPENDED' -%}
+        {%- do active.append(1) -%}
+      {%- endif -%}
+    {%- endif -%}
+  {%- endfor -%}
+
+  select 'materialization {{ materialization_name }} does not exist on {{ model }}' as error_message
+  where {{ found | length }} = 0
+  union all
+  select 'materialization {{ materialization_name }} is suspended on {{ model }}' as error_message
+  where {{ found | length }} > 0 and {{ active | length }} = 0
+{% endtest %}


### PR DESCRIPTION
## Summary

  - Adds a `create_or_alter` config option that emits `CREATE OR ALTER SEMANTIC VIEW` DDL instead of `CREATE OR REPLACE`, preserving existing materializations and grants when only the SV body changes.
  - Adds a `sv_materializations` config option that declaratively syncs materializations on a semantic view by calling `SYSTEM$MANAGE_SEMANTIC_VIEW_MATERIALIZATIONS_FROM_YAML` after each model run.
  - Adds example model and test model demonstrating the new config options.
  - Updates README with documentation and usage examples for both new features.
