### PR TITLE
Add ca_extensions macro for Cortex Analyst verified queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,71 @@ from semantic_view(
 )
 ```
 
+### Cortex Analyst enrichments (`ca_extensions`)
+
+The `ca_extensions` macro generates the `WITH EXTENSION (CA=$$...$$)` block that enriches a semantic view for [Cortex Analyst](https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-analyst). Use it to attach **verified queries**, **custom instructions**, **relationships**, and per-table metadata without hand-writing JSON.
+
+**Parameters**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `verified_queries` | list of dicts | Pre-verified SQL + natural-language question pairs shown in the Cortex Analyst UI |
+| `custom_instructions` | str | Free-text instructions appended to every Cortex Analyst prompt for this view |
+| `relationships` | list of dicts | Cross-table relationship definitions |
+| `tables` | list of dicts | Per-table Cortex Analyst metadata (synonyms, filters, etc.) |
+
+**Verified query fields**
+
+| Field | Required | Description |
+|---|---|---|
+| `name` | yes | Short label shown in the UI |
+| `question` | yes | Natural-language question this SQL answers |
+| `sql` | yes | Verified SQL (use table aliases from `TABLES(...)`, not fully-qualified names) |
+| `verified_at` | no | Unix timestamp of verification |
+| `verified_by` | no | Name of the person who verified |
+| `use_as_onboarding_question` | no | Surface this question in the onboarding flow |
+
+**Example**
+
+```sql
+{{ config(materialized='semantic_view') }}
+
+TABLES(orders AS {{ ref('orders') }})
+DIMENSIONS(orders.status AS status)
+METRICS(orders.order_count AS COUNT(*))
+
+{{ dbt_semantic_view.ca_extensions(
+    verified_queries=[
+        {
+            "name": "total orders last 30 days",
+            "question": "How many orders were placed in the last 30 days?",
+            "sql": "SELECT COUNT(*) AS order_count FROM orders WHERE order_date >= CURRENT_DATE - 30",
+            "verified_at": 1733356800,
+            "verified_by": "Jane Smith",
+            "use_as_onboarding_question": true
+        }
+    ],
+    custom_instructions="Always filter to completed orders unless the user specifies otherwise."
+) }}
+```
+
+This renders as:
+
+```sql
+CREATE OR REPLACE SEMANTIC VIEW <name>
+TABLES(orders AS ...)
+DIMENSIONS(orders.status AS status)
+METRICS(orders.order_count AS COUNT(*))
+with extension (CA=$$
+{
+  "verified_queries": [{"name": "total orders last 30 days", ...}],
+  "custom_instructions": "Always filter to completed orders unless the user specifies otherwise."
+}
+$$)
+```
+
+All parameters are optional — `ca_extensions` only includes keys that have values, so you can start with just `verified_queries` and add the rest later.
+
 ### Note on documentation persistence (persist_docs)
 At this time, dbt-driven documentation persistence for Semantic Views (`persist_docs`) is not supported by this package. Enabling `persist_docs` and adding model or column descriptions will not affect Semantic Views.
 

--- a/integration_tests/models/semantic_view_with_verified_queries.sql
+++ b/integration_tests/models/semantic_view_with_verified_queries.sql
@@ -1,0 +1,34 @@
+-- Copyright 2025 Snowflake Inc.
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+{{ config(materialized='semantic_view') }}
+
+TABLES(t1 AS {{ ref('base_table') }}, t2 as {{ source('seed_sources', 'base_table2') }})
+DIMENSIONS(t1.count as value, t2.volume as value)
+METRICS(t1.total_rows AS SUM(t1.count), t2.max_volume as max(t2.volume))
+
+{{ dbt_semantic_view.ca_extensions(
+    verified_queries=[
+        {
+            "name": "total rows",
+            "question": "What is the total number of rows?",
+            "sql": "SELECT SUM(t1.count) AS total_rows FROM t1",
+            "verified_at": 1733356800,
+            "verified_by": "test_user",
+            "use_as_onboarding_question": true
+        }
+    ],
+    custom_instructions="Always aggregate at the row level unless otherwise specified."
+) }}

--- a/macros/ca_extensions.sql
+++ b/macros/ca_extensions.sql
@@ -1,0 +1,84 @@
+-- Copyright 2025 Snowflake Inc.
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+{#
+  ca_extensions — generate the WITH EXTENSION (CA=$$...$$) block for Cortex Analyst.
+
+  Parameters
+  ----------
+  verified_queries : list of dicts
+      Each dict must have:
+        - name            (str)  short label shown in the UI
+        - question        (str)  natural-language question this SQL answers
+        - sql             (str)  verified SQL (use table aliases, not fully-qualified names)
+      Optional keys:
+        - verified_at     (int)  Unix timestamp of verification
+        - verified_by     (str)  name of the person who verified
+        - use_as_onboarding_question (bool)  surface in the onboarding flow
+
+  relationships : list of dicts
+      Cortex Analyst relationship definitions (see Snowflake docs).
+
+  custom_instructions : str
+      Free-text instructions appended to every Cortex Analyst prompt for this view.
+
+  tables : list of dicts
+      Per-table Cortex Analyst metadata (filters, synonyms, etc.).
+
+  Usage
+  -----
+  {{ config(materialized='semantic_view') }}
+  TABLES(t1 AS {{ ref('orders') }})
+  DIMENSIONS(t1.status AS status)
+  METRICS(t1.order_count AS COUNT(*))
+  {{ dbt_semantic_view.ca_extensions(
+      verified_queries=[
+          {
+              "name": "total orders last 30 days",
+              "question": "How many orders were placed in the last 30 days?",
+              "sql": "SELECT COUNT(*) AS order_count FROM t1 WHERE order_date >= CURRENT_DATE - 30",
+              "verified_at": 1733356800,
+              "verified_by": "Jane Smith",
+              "use_as_onboarding_question": true
+          }
+      ],
+      custom_instructions="Always filter to completed orders unless the user specifies otherwise."
+  ) }}
+#}
+
+{% macro ca_extensions(relationships=[], verified_queries=[], custom_instructions='', tables=[]) %}
+
+{%- set ca_items = [] -%}
+  {%- if tables -%}
+      {%- do ca_items.append('"tables": ' ~ (tables | tojson)) -%}
+  {%- endif -%}
+  {%- if relationships -%}
+      {%- do ca_items.append('"relationships": ' ~ (relationships | tojson)) -%}
+  {%- endif -%}
+  {%- if verified_queries -%}
+      {%- do ca_items.append('"verified_queries": ' ~ (verified_queries | tojson)) -%}
+  {%- endif -%}
+  {%- if custom_instructions -%}
+      {%- do ca_items.append('"custom_instructions": ' ~ (custom_instructions | tojson)) -%}
+  {%- endif -%}
+
+    {% if ca_items -%}
+    with extension (CA=$$
+{
+  {{ ca_items | join(',\n  ') | indent(2, true) }}
+}
+$$)
+    {%- endif %}
+{% endmacro %}


### PR DESCRIPTION
## Summary

It is annoying that our dbt setup doesn't include the ability to use custom instructions and VQRs, this is how the product data team handles this in our materialization. Thought I would go and fix!

Now to the Coco summary:

- Adds a `ca_extensions` Jinja macro (`macros/ca_extensions.sql`) that generates the `WITH EXTENSION (CA=$$...$$)` block for Cortex Analyst enrichments
- Supports `verified_queries`, `custom_instructions`, `relationships`, and per-table `tables` metadata — only emits keys that have values
- Adds an integration test model (`integration_tests/models/semantic_view_with_verified_queries.sql`) that exercises the macro end-to-end
- Documents the macro in README under a new 'Cortex Analyst enrichments' section with a parameter table, field reference, and complete example

## Motivation

The existing `semantic_view_with_ca_extension.sql` integration test shows that users currently have to hand-write raw JSON strings in the `with extension` clause. That is error-prone and hard to maintain. This macro lets users define verified queries as structured Jinja dicts and relies on `| tojson` for correct serialisation.
